### PR TITLE
Enable IAM roles for service account

### DIFF
--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -30,8 +30,7 @@ module "cluster" {
   cluster_name                          = var.cluster_name
   cluster_version                       = var.cluster_version
   create_eks                            = true
-  eks_oidc_root_ca_thumbprint           = ""
-  enable_irsa                           = false
+  enable_irsa                           = true
   iam_path                              = "/${var.cluster_name}/"
   kubeconfig_name                       = var.cluster_name
   subnets                               = var.subnetworks


### PR DESCRIPTION
The aim of this PR is to enable IAM roles for service accounts in order to increase the cluster security.

No direct user facing changes and no impact on billing.

Refs:
- https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html
- https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/
- https://github.com/terraform-aws-modules/terraform-aws-eks/tree/master/examples/irsa