### PR TITLE
Adding subnets on nodes interface

### DIFF
--- a/example/my-cluster.tfvars
+++ b/example/my-cluster.tfvars
@@ -16,7 +16,7 @@ node_pools = [
     max_size : 2
     instance_type : "m5.large"
     volume_size : 100
-    subnets: null
+    subnetworks : null
     labels : {
       "node.kubernetes.io/role" : "app"
       "sighup.io/fury-release" : "v1.3.0"
@@ -32,7 +32,7 @@ node_pools = [
     max_size : 1
     instance_type : "t3.micro"
     volume_size : 50
-    subnets: null
+    subnetworks : null
     labels : {}
     taints : [
       "sighup.io/role=app:NoSchedule"

--- a/example/my-cluster.tfvars
+++ b/example/my-cluster.tfvars
@@ -16,6 +16,7 @@ node_pools = [
     max_size : 2
     instance_type : "m5.large"
     volume_size : 100
+    subnets: null
     labels : {
       "node.kubernetes.io/role" : "app"
       "sighup.io/fury-release" : "v1.3.0"
@@ -31,6 +32,7 @@ node_pools = [
     max_size : 1
     instance_type : "t3.micro"
     volume_size : 50
+    subnets: null
     labels : {}
     taints : [
       "sighup.io/role=app:NoSchedule"

--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -15,7 +15,7 @@ locals {
       "instance_type" : worker.instance_type,
       "tags" : [for tag_key, tag_value in merge(merge(local.default_node_tags, var.tags), worker.tags) : { "key" : tag_key, "value" : tag_value, "propagate_at_launch" : true }],
       "volume_size" : worker.volume_size,
-      "subnets" : worker.subnets != null ? worker.subnets : var.subnetworks
+      "subnetworks" : worker.subnetworks != null ? worker.subnetworks : var.subnetworks
       "bootstrap_extra_args" : "%{if lookup(worker, "max_pods", null) != null}--use-max-pods false%{endif}",
       "kubelet_extra_args" : <<EOT
 %{if lookup(worker, "max_pods", null) != null}--max-pods ${worker.max_pods} %{endif}--node-labels sighup.io/cluster=${var.cluster_name},sighup.io/node_pool=${worker.name},%{for k, v in worker.labels}${k}=${v},%{endfor}
@@ -64,7 +64,7 @@ module "cluster" {
       root_volume_size              = lookup(node_pool, "volume_size")
       key_name                      = aws_key_pair.nodes.key_name
       public_ip                     = false
-      subnets                       = lookup(node_pool, "subnets")
+      subnets                       = lookup(node_pool, "subnetworks")
       additional_security_group_ids = [aws_security_group.nodes.id]
       cpu_credits                   = "unlimited" # Avoid t2/t3 throttling
       kubelet_extra_args            = replace(trimsuffix(chomp(lookup(node_pool, "kubelet_extra_args")), ","), "\n", " ")

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -38,7 +38,7 @@ variable "node_pools" {
     instance_type = string
     max_pods      = number # null to use default upstream configuration
     volume_size   = number
-    subnets       = list(string) # null to use default upstream configuration
+    subnetworks   = list(string) # null to use default upstream configuration
     labels        = map(string)
     taints        = list(string)
     tags          = map(string)

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -38,6 +38,7 @@ variable "node_pools" {
     instance_type = string
     max_pods      = number # null to use default upstream configuration
     volume_size   = number
+    subnets       = list(string) # null to use default upstream configuration
     labels        = map(string)
     taints        = list(string)
     tags          = map(string)


### PR DESCRIPTION
Hi team! 

i'm proposing this addition on the nodes interface (can be made also on other installers).

The new key `subnets` changes the subnet used by ASGs. Useful when you have some zonal PVC attached to small nodegroups.

To maintain the current behaviour, you will need only to add `subnet: null` value on the nodepool map