### PR TITLE
Add a new output: cluster_oidc_issuer_url

### DIFF
--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -31,3 +31,4 @@
 | cluster_certificate_authority | The base64 encoded certificate data required to communicate with your cluster. Add this to the certificate-authority-data section of the kubeconfig file for your cluster |
 | cluster_endpoint              | The endpoint for your Kubernetes API server                                                                                                                               |
 | operator_ssh_user             | SSH user to access cluster nodes with ssh_public_key                                                                                                                      |
+| eks_cluster_oidc_issuer_url   | The URL on the EKS cluster OIDC Issuer                                                                                                                                    |

--- a/modules/eks/output.tf
+++ b/modules/eks/output.tf
@@ -12,3 +12,8 @@ output "operator_ssh_user" {
   description = "SSH user to access cluster nodes with ssh_public_key"
   value       = "ec2-user" # Default
 }
+
+output "eks_cluster_oidc_issuer_url" {
+  description = "The URL on the EKS cluster OIDC Issuer"
+  value       = module.cluster.cluster_oidc_issuer_url
+}


### PR DESCRIPTION
We found that in some scenarios we need the `cluster_oidc_issuer_url` output from the upstream terraform module. 
The main reason is that the terraform provider is not able to grab that info from the `data` attribute in terraform. So outputting this value is a must.

Here the detailed information: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster#identity