### PR TITLE
Enforcing Terraform 0.15.4

### DIFF
--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -2,10 +2,10 @@
 
 ## Providers
 
-| Name       | Version   |
-| ---------- | --------- |
-| aws        | >= 2.70.0 |
-| kubernetes | = 1.13.3  |
+| Name       | Version |
+| ---------- | ------- |
+| aws        | 2.70.0  |
+| kubernetes | 1.13.3  |
 
 ## Inputs
 

--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -28,7 +28,7 @@ EOT
 
 module "cluster" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "13.0.0"
+  version = "16.1.0"
 
   cluster_create_timeout                         = "30m"
   cluster_delete_timeout                         = "30m"

--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -28,7 +28,7 @@ EOT
 
 module "cluster" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "16.1.0"
+  version = "16.2.0"
 
   cluster_create_timeout                         = "30m"
   cluster_delete_timeout                         = "30m"

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = "0.15.4"
   required_providers {
-    aws        = "= 3.37.0"
-    kubernetes = "= 1.13.3"
+    aws        = "3.37.0"
+    kubernetes = "1.13.3"
   }
 }

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = "0.15.4"
   required_providers {
-    aws        = ">= 2.70.0"
+    aws        = "= 3.37.0"
     kubernetes = "= 1.13.3"
   }
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -46,12 +46,12 @@ variable "node_pools" {
     taints        = list(string)
     tags          = map(string)
     additional_firewall_rules = list(object({
-      name        = string
-      direction   = string
-      cidr_block  = string
-      protocol    = string
-      ports       = string
-      tags        = map(string)
+      name       = string
+      direction  = string
+      cidr_block = string
+      protocol   = string
+      ports      = string
+      tags       = map(string)
     }))
   }))
   default = []

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -14,7 +14,7 @@ variable "network" {
 }
 
 variable "subnetworks" {
-  type        = list
+  type        = list(any)
   description = "List of subnets where the cluster will be hosted"
 }
 
@@ -58,7 +58,7 @@ variable "node_pools" {
 }
 
 variable "tags" {
-  type        = map
+  type        = map(any)
   description = "The tags to apply to all resources"
   default     = {}
 }

--- a/modules/vpc-and-vpn/README.md
+++ b/modules/vpc-and-vpn/README.md
@@ -2,12 +2,12 @@
 
 ## Providers
 
-| Name     | Version   |
-| -------- | --------- |
-| aws      | ~> 3.19.0 |
-| external | ~> 2.0    |
-| local    | ~> 2.0    |
-| null     | ~> 3.0    |
+| Name     | Version |
+| -------- | ------- |
+| aws      | 3.19.0  |
+| external | 2.0     |
+| local    | 2.0     |
+| null     | 3.0     |
 
 ## Inputs
 

--- a/modules/vpc-and-vpn/main.tf
+++ b/modules/vpc-and-vpn/main.tf
@@ -1,9 +1,9 @@
 terraform {
   required_version = "0.15.4"
   required_providers {
-    local = "= 2.0.0"
-    null = "= 3.0.0"
-    aws        = "= 3.19.0"
+    local    = "= 2.0.0"
+    null     = "= 3.0.0"
+    aws      = "= 3.19.0"
     external = "= 2.0.0"
   }
 }

--- a/modules/vpc-and-vpn/main.tf
+++ b/modules/vpc-and-vpn/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = "0.15.4"
+}
+
 data "aws_region" "current" {}
 
 data "aws_availability_zones" "available" {}

--- a/modules/vpc-and-vpn/main.tf
+++ b/modules/vpc-and-vpn/main.tf
@@ -1,10 +1,10 @@
 terraform {
   required_version = "0.15.4"
   required_providers {
-    local    = "= 2.0.0"
-    null     = "= 3.0.0"
-    aws      = "= 3.19.0"
-    external = "= 2.0.0"
+    local    = "2.0.0"
+    null     = "3.0.0"
+    aws      = "3.19.0"
+    external = "2.0.0"
   }
 }
 

--- a/modules/vpc-and-vpn/main.tf
+++ b/modules/vpc-and-vpn/main.tf
@@ -1,5 +1,11 @@
 terraform {
   required_version = "0.15.4"
+  required_providers {
+    local = "= 2.0.0"
+    null = "= 3.0.0"
+    aws        = "= 3.19.0"
+    external = "= 2.0.0"
+  }
 }
 
 data "aws_region" "current" {}
@@ -17,20 +23,4 @@ locals {
     "eu-north-1" : "ami-01450210d4ebb3bab"
     "eu-central-1" : "ami-09f14afb2e15caab5"
   }
-}
-
-provider "local" {
-  version = "~> 2.0"
-}
-
-provider "null" {
-  version = "~> 3.0"
-}
-
-provider "aws" {
-  version = "~> 3.19.0"
-}
-
-provider "external" {
-  version = "~> 2.0"
 }


### PR DESCRIPTION
This PR contains the enforcement of terraform 0.15.4 in order to standardize our terraform default version across projects.