### PR TITLE
Use an experimental feature to avoid setting the max-pods nodepool attribute

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -1,3 +1,7 @@
+terraform {
+  required_version = "0.15.4"
+}
+
 variable "cluster_name" {}
 variable "cluster_version" {}
 variable "network" {}

--- a/example/my-cluster.tfvars
+++ b/example/my-cluster.tfvars
@@ -53,7 +53,7 @@ node_pools = [
     tags : {
       "node-tags" : "exists"
     }
-    max_pods : null # To use default EKS setting
+    # max_pods : null # To use default EKS setting set it to null or do not set it
   },
   {
     name : "t3-node-pool"

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,4 +1,5 @@
 terraform {
+  experiments = [module_variable_optional_attrs]
   required_version = "0.15.4"
   required_providers {
     aws        = "3.37.0"

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -40,7 +40,7 @@ variable "node_pools" {
     max_size              = number
     instance_type         = string
     spot_instance         = bool
-    max_pods              = number # null to use default upstream configuration
+    max_pods              = optional(number) # null to use default upstream configuration
     volume_size           = number
     subnetworks           = list(string) # null to use default upstream configuration
     labels                = map(string)


### PR DESCRIPTION
This tries to solve the #16 issue.

I discovered the following terraform >0.14 feature: https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes

Having a structure as we have:

```hcl
variable "node_pools" {
  description = "An object list defining node pools configurations"
  type = list(object({
    name                  = string
    version               = string # null to use cluster_version
    min_size              = number
    max_size              = number
    instance_type         = string
    spot_instance         = bool
    max_pods              = number # null to use default upstream configuration
    volume_size           = number
    subnetworks           = list(string) # null to use default upstream configuration
    labels                = map(string)
    taints                = list(string)
    tags                  = map(string)
    eks_target_group_arns = list(string)
    additional_firewall_rules = list(object({
      name       = string
      direction  = string
      cidr_block = string
      protocol   = string
      ports      = string
      tags       = map(string)
    }))
  }))
  default = []
}
```

It was impossible (til that feature) to omit to pass an attribute (all of them were required, you can always set them with `null` as its value).

Now with this PR, we are enabling the `optional()` feature/function to make some attributes optional/non-required solving the problem with the `max-pods` described in #16.

If we agree to implement this feature, we should push this change to the rest of the cloud installers, then apply the change on `furyctl`.

Thanks