### PR TITLE
update EKS provider to v17

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,37 @@
+# Fury EKS Installer Example
+
+This folder contains working examples of the terraform modules provided by this Fury Installer.
+
+In order to test them, you follow the instructions below.
+Note all comments starting with `TASK: ` require you to run some manual action on your computer
+that cannot be automated with the following script.
+
+```bash
+# First of all, export the needed env vars for the aws provider to work
+export AWS_ACCESS_KEY_ID=<YOUR_ACCESS_KEY_ID>
+export AWS_SECRET_ACCESS_KEY=<SECRET_ACCESS_KEY>
+export AWS_REGION=<YOUR_REGION>
+
+# Bring up the vpc and vpn
+cd example/vpc-and-vpn
+cp main.auto.tfvars.dist main.auto.tfvars
+# TASK: fill in main.auto.tfvars with your data
+terraform init
+terraform apply
+
+# Create a OpenVPN client certificate using furyagent
+furyagent configure openvpn-client --config=./secrets/furyagent.yml --client-name test > /tmp/fury-example-test.ovpn
+# TASK: import the generated /tmp/fury-example-test.ovpn in the openvpn client of your choice and turn it on.
+
+cd ../eks
+cp main.auto.tfvars.dist main.auto.tfvars
+# TASK: fill in main.auto.tfvars with your data
+terraform init
+terraform apply
+
+# Once all the above is done you can dump the kube config to a file of your choice
+terraform output -raw kubeconfig > /var/tmp/.kubeconfig
+
+# Last but not least, you can verify your cluster is up and running
+KUBECONFIG=/var/tmp/.kubeconfig kubectl get nodes
+```

--- a/example/eks/main.auto.tfvars.dist
+++ b/example/eks/main.auto.tfvars.dist
@@ -1,0 +1,1 @@
+ssh_public_key = "content of a public ssh key of your choice (eg: ~/.ssh/id_rsa.pub)"

--- a/example/eks/main.tf
+++ b/example/eks/main.tf
@@ -8,7 +8,7 @@ data "terraform_remote_state" "vpc_and_vpn" {
 module "fury_example" {
   source = "../../modules/eks"
 
-  cluster_name    = "fury-example"
+  cluster_name    = "fury-example"  # mae sure to use the same name you used in the bootstrap.yml file
   cluster_version = "1.24"
 
   network     = data.terraform_remote_state.vpc_and_vpn.outputs.vpc_id

--- a/example/eks/main.tf
+++ b/example/eks/main.tf
@@ -1,23 +1,22 @@
-terraform {
-  required_version = "0.15.4"
+data "terraform_remote_state" "vpc_and_vpn" {
+  backend = "local"
+  config = {
+    path = "${path.module}/../vpc-and-vpn/terraform.tfstate"
+  }
 }
 
-module "my-cluster" {
+module "fury_example" {
   source = "../../modules/eks"
 
-  cluster_name    = "my-cluster"
-  cluster_version = "1.20"
+  cluster_name    = "fury-example"
+  cluster_version = "1.24"
 
-  network         = "vpc-id0"
-  subnetworks = [
-    "subnet-id1",
-    "subnet-id2",
-    "subnet-id3",
-  ]
+  network     = data.terraform_remote_state.vpc_and_vpn.outputs.vpc_id
+  subnetworks = data.terraform_remote_state.vpc_and_vpn.outputs.private_subnets
 
-  ssh_public_key = "ssh-rsa example"
-  dmz_cidr_range = "10.0.4.0/24"
-  
+  ssh_public_key = var.ssh_public_key
+  dmz_cidr_range = "10.0.0.0/16"
+
   node_pools = [
     {
       name : "m5-node-pool"
@@ -25,6 +24,7 @@ module "my-cluster" {
       min_size : 1
       max_size : 2
       instance_type : "m5.large"
+      spot_instance: true
       volume_size : 100
       subnetworks : null
       eks_target_group_arns : null
@@ -43,7 +43,7 @@ module "my-cluster" {
       ]
       labels : {
         "node.kubernetes.io/role" : "app"
-        "sighup.io/fury-release" : "v1.23.1"
+        "sighup.io/fury-release" : "v1.24.0"
       }
       taints : []
       tags : {
@@ -57,7 +57,8 @@ module "my-cluster" {
       max_size : 2
       instance_type : "m5.large"
       spot_instance : true # optionally create spot instances
-      os : "ami-0caf35bc73450c396" # optionally define a custom AMI
+      # os : "ami-0caf35bc73450c396" # optionally define a custom AMI
+      # os: "ami-0ab303329574a0338"
       volume_size : 100
       subnetworks : null
       eks_target_group_arns : null
@@ -76,7 +77,7 @@ module "my-cluster" {
       ]
       labels : {
         "node.kubernetes.io/role" : "app"
-        "sighup.io/fury-release" : "v1.23.1"
+        "sighup.io/fury-release" : "v1.24.0"
       }
       taints : []
       tags : {
@@ -87,7 +88,7 @@ module "my-cluster" {
   ]
 
   tags = {
-    "my-tags" : "my-value"
+    Environment: "kfd-development"
   }
 
   eks_map_users    = []

--- a/example/eks/main.tf
+++ b/example/eks/main.tf
@@ -8,7 +8,7 @@ data "terraform_remote_state" "vpc_and_vpn" {
 module "fury_example" {
   source = "../../modules/eks"
 
-  cluster_name    = "fury-example"  # make sure to use the same name you used in the bootstrap.yml file
+  cluster_name    = "fury-example"  # make sure to use the same name you used in the VPC and VPN module
   cluster_version = "1.24"
 
   network     = data.terraform_remote_state.vpc_and_vpn.outputs.vpc_id

--- a/example/eks/main.tf
+++ b/example/eks/main.tf
@@ -8,7 +8,7 @@ data "terraform_remote_state" "vpc_and_vpn" {
 module "fury_example" {
   source = "../../modules/eks"
 
-  cluster_name    = "fury-example"  # mae sure to use the same name you used in the bootstrap.yml file
+  cluster_name    = "fury-example"  # make sure to use the same name you used in the bootstrap.yml file
   cluster_version = "1.24"
 
   network     = data.terraform_remote_state.vpc_and_vpn.outputs.vpc_id

--- a/example/eks/main.tf
+++ b/example/eks/main.tf
@@ -58,7 +58,6 @@ module "fury_example" {
       instance_type : "m5.large"
       spot_instance : true # optionally create spot instances
       # os : "ami-0caf35bc73450c396" # optionally define a custom AMI
-      # os: "ami-0ab303329574a0338"
       volume_size : 100
       subnetworks : null
       eks_target_group_arns : null

--- a/example/eks/output.tf
+++ b/example/eks/output.tf
@@ -1,11 +1,11 @@
-output "kube_config" {
+output "kubeconfig" {
   sensitive = true
   value     = <<EOT
 apiVersion: v1
 clusters:
 - cluster:
-    server: ${module.my-cluster.cluster_endpoint}
-    certificate-authority-data: ${module.my-cluster.cluster_certificate_authority}
+    server: ${module.fury_example.cluster_endpoint}
+    certificate-authority-data: ${module.fury_example.cluster_certificate_authority}
   name: kubernetes
 contexts:
 - context:
@@ -19,7 +19,7 @@ users:
 - name: aws
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: aws
       args:
         - "eks"

--- a/example/eks/variables.tf
+++ b/example/eks/variables.tf
@@ -1,0 +1,10 @@
+variable "cluster_name" {
+  type        = string
+  default     = "fury-example"
+  description = "Unique cluster name. Used in multiple resources to identify your cluster resources"
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "SSH public key to be used to access the cluster nodes"
+}

--- a/example/vpc-and-vpn/main.auto.tfvars.dist
+++ b/example/vpc-and-vpn/main.auto.tfvars.dist
@@ -1,0 +1,2 @@
+# GitHub usernames from whom the node will pull the public keys to allow ssh connections.
+vpn_ssh_users = ["ralgozino"]

--- a/example/vpc-and-vpn/main.auto.tfvars.dist
+++ b/example/vpc-and-vpn/main.auto.tfvars.dist
@@ -1,2 +1,2 @@
 # GitHub usernames from whom the node will pull the public keys to allow ssh connections.
-vpn_ssh_users = ["ralgozino"]
+vpn_ssh_users = []

--- a/example/vpc-and-vpn/main.tf
+++ b/example/vpc-and-vpn/main.tf
@@ -1,16 +1,12 @@
-terraform {
-  required_version = "0.15.4"
-}
-
-module "vpc-and-vpn" {
+module "vpc_and_vpn" {
     source = "../../modules/vpc-and-vpn"
 
-    name = "fury"
-    
+    name = "fury-example"
+
     network_cidr = "10.0.0.0/16"
     public_subnetwork_cidrs = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
     private_subnetwork_cidrs = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-    
-    vpn_subnetwork_cidr = "192.168.200.0/24"
-    vpn_ssh_users = ["github-user"]
+
+    vpn_subnetwork_cidr = "10.0.201.0/24"
+    vpn_ssh_users = var.vpn_ssh_users
 }

--- a/example/vpc-and-vpn/main.tf
+++ b/example/vpc-and-vpn/main.tf
@@ -1,7 +1,7 @@
 module "vpc_and_vpn" {
     source = "../../modules/vpc-and-vpn"
 
-    name = "fury-example"
+    name = "fury-example"  # make sure to use the same name in the cluster.yml file
 
     network_cidr = "10.0.0.0/16"
     public_subnetwork_cidrs = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]

--- a/example/vpc-and-vpn/main.tf
+++ b/example/vpc-and-vpn/main.tf
@@ -1,7 +1,7 @@
 module "vpc_and_vpn" {
     source = "../../modules/vpc-and-vpn"
 
-    name = "fury-example"  # make sure to use the same name in the cluster.yml file
+    name = "fury-example"  # make sure to use the same name value as cluster name
 
     network_cidr = "10.0.0.0/16"
     public_subnetwork_cidrs = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]

--- a/example/vpc-and-vpn/output.tf
+++ b/example/vpc-and-vpn/output.tf
@@ -1,0 +1,13 @@
+output "vpc_id" {
+  value = module.vpc_and_vpn.vpc_id
+}
+
+output "public_subnets" {
+  description = "List of IDs of public subnets"
+  value       = module.vpc_and_vpn.public_subnets
+}
+
+output "private_subnets" {
+  description = "List of IDs of private subnets"
+  value       = module.vpc_and_vpn.private_subnets
+}

--- a/example/vpc-and-vpn/variables.tf
+++ b/example/vpc-and-vpn/variables.tf
@@ -1,0 +1,4 @@
+variable "vpn_ssh_users" {
+  type        = list(string)
+  description = "List of ssh users to be added to the VPN instance"
+}

--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -54,7 +54,7 @@ EOT
 
 module "cluster" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "16.2.0"
+  version = "17.24.0"
 
   cluster_create_timeout                         = "30m"
   cluster_delete_timeout                         = "30m"

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -2,7 +2,7 @@ terraform {
   experiments      = [module_variable_optional_attrs]
   required_version = "0.15.4"
   required_providers {
-    aws        = "3.37.0"
+    aws        = "3.56.0"
     kubernetes = "1.13.3"
   }
 }

--- a/modules/vpc-and-vpn/README.md
+++ b/modules/vpc-and-vpn/README.md
@@ -1,80 +1,75 @@
 <!-- BEGIN_TF_DOCS -->
 
-# Fury EKS Installer - vpc-and-vpn module
+# Fury EKS Installer - VPC and VPN module
 
 <!-- <KFD-DOCS> -->
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| terraform | 0.15.4 |
-| aws | 3.37.0 |
-| external | 2.0.0 |
-| local | 2.0.0 |
-| null | 3.0.0 |
+| Name      | Version |
+| --------- | ------- |
+| terraform | 0.15.4  |
+| aws       | 3.56.0  |
+| external  | 2.0.0   |
+| local     | 2.0.0   |
+| null      | 3.0.0   |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| aws | 3.37.0 |
-| external | 2.0.0 |
-| local | 2.0.0 |
-| null | 3.0.0 |
+| Name     | Version |
+| -------- | ------- |
+| aws      | 3.56.0  |
+| external | 2.0.0   |
+| local    | 2.0.0   |
+| null     | 3.0.0   |
 
 ## Inputs
 
-| Name | Description | Default | Required |
-|------|-------------|---------|:--------:|
-| name | Name of the resources. Used as cluster name | n/a | yes |
-| network\_cidr | VPC Network CIDR | n/a | yes |
-| private\_subnetwork\_cidrs | Private subnet CIDRs | n/a | yes |
-| public\_subnetwork\_cidrs | Public subnet CIDRs | n/a | yes |
-| tags | A map of tags to add to all resources | `{}` | no |
-| vpn\_dhparams\_bits | Diffie–Hellman (D-H) key size in bytes | `2048` | no |
-| vpn\_instance\_disk\_size | VPN main disk size | `50` | no |
-| vpn\_instance\_type | EC2 instance type | `"t3.micro"` | no |
-| vpn\_instances | VPN Servers | `1` | no |
-| vpn\_operator\_cidrs | VPN Operator cidrs. Used to log into the instance via SSH | ```[ "0.0.0.0/0" ]``` | no |
-| vpn\_operator\_name | VPN operator name. Used to log into the instance via SSH | `"sighup"` | no |
-| vpn\_port | VPN Server Port | `1194` | no |
-| vpn\_ssh\_users | GitHub users id to sync public rsa keys. Example angelbarrera92 | n/a | yes |
-| vpn\_subnetwork\_cidr | VPN Subnet CIDR, should be different from the network\_cidr | n/a | yes |  
+| Name                       | Description                                                     | Default               | Required |
+| -------------------------- | --------------------------------------------------------------- | --------------------- | :------: |
+| name                       | Name of the resources. Used as cluster name                     | n/a                   |   yes    |
+| network\_cidr              | VPC Network CIDR                                                | n/a                   |   yes    |
+| private\_subnetwork\_cidrs | Private subnet CIDRs                                            | n/a                   |   yes    |
+| public\_subnetwork\_cidrs  | Public subnet CIDRs                                             | n/a                   |   yes    |
+| tags                       | A map of tags to add to all resources                           | `{}`                  |    no    |
+| vpn\_dhparams\_bits        | Diffie-Hellman (D-H) key size in bytes                          | `2048`                |    no    |
+| vpn\_instance\_disk\_size  | VPN main disk size                                              | `50`                  |    no    |
+| vpn\_instance\_type        | EC2 instance type                                               | `"t3.micro"`          |    no    |
+| vpn\_instances             | VPN Servers                                                     | `1`                   |    no    |
+| vpn\_operator\_cidrs       | VPN Operator cidrs. Used to log into the instance via SSH       | ```[ "0.0.0.0/0" ]``` |    no    |
+| vpn\_operator\_name        | VPN operator name. Used to log into the instance via SSH        | `"sighup"`            |    no    |
+| vpn\_port                  | VPN Server Port                                                 | `1194`                |    no    |
+| vpn\_ssh\_users            | GitHub users id to sync public rsa keys. Example angelbarrera92 | n/a                   |   yes    |
+| vpn\_subnetwork\_cidr      | VPN Subnet CIDR, should be different from the network\_cidr     | n/a                   |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| furyagent | furyagent.yml used by the vpn instance and ready to use to create a vpn profile |
-| private\_subnets | List of IDs of private subnets |
-| private\_subnets\_cidr\_blocks | List of cidr\_blocks of private subnets |
-| public\_subnets | List of IDs of public subnets |
-| public\_subnets\_cidr\_blocks | List of cidr\_blocks of public subnets |
-| vpc\_cidr\_block | The CIDR block of the VPC |
-| vpc\_id | The ID of the VPC |
-| vpn\_ip | VPN instance IP |
+| Name                           | Description                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------- |
+| furyagent                      | furyagent.yml used by the vpn instance and ready to use to create a vpn profile |
+| private\_subnets               | List of IDs of private subnets                                                  |
+| private\_subnets\_cidr\_blocks | List of cidr\_blocks of private subnets                                         |
+| public\_subnets                | List of IDs of public subnets                                                   |
+| public\_subnets\_cidr\_blocks  | List of cidr\_blocks of public subnets                                          |
+| vpc\_cidr\_block               | The CIDR block of the VPC                                                       |
+| vpc\_id                        | The ID of the VPC                                                               |
+| vpn\_ip                        | VPN instance IP                                                                 |
 
 ## Usage
 
 ```hcl
-terraform {
-  required_version = "0.15.4"
-}
-
-module "vpc-and-vpn" {
+module "vpc_and_vpn" {
     source = "../../modules/vpc-and-vpn"
 
-    name = "fury"
-    
+    name = "fury-example"
+
     network_cidr = "10.0.0.0/16"
     public_subnetwork_cidrs = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
     private_subnetwork_cidrs = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
-    
-    vpn_subnetwork_cidr = "192.168.200.0/24"
-    vpn_ssh_users = ["github-user"]
-}
 
+    vpn_subnetwork_cidr = "10.0.201.0/24"
+    vpn_ssh_users = var.vpn_ssh_users
+}
 ```
 
 <!-- </KFD-DOCS> -->

--- a/modules/vpc-and-vpn/main.tf
+++ b/modules/vpc-and-vpn/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local    = "2.0.0"
     null     = "3.0.0"
-    aws      = "3.37.0"
+    aws      = "3.56.0"
     external = "2.0.0"
   }
 }

--- a/modules/vpc-and-vpn/vpn.tf
+++ b/modules/vpc-and-vpn/vpn.tf
@@ -87,7 +87,7 @@ resource "aws_instance" "vpn" {
   root_block_device {
     volume_size = var.vpn_instance_disk_size
   }
-  tags = merge({"Name": "${var.name}-vpn"}, var.tags)
+  tags = merge({ "Name" : "${var.name}-vpn-${count.index}" }, var.tags)
 }
 
 resource "aws_eip_association" "vpn" {

--- a/modules/vpc-and-vpn/vpn.tf
+++ b/modules/vpc-and-vpn/vpn.tf
@@ -13,7 +13,7 @@ locals {
     openvpn_routes         = [{ "network" : cidrhost(var.network_cidr, 0), "netmask" : cidrnetmask(var.network_cidr) }],
     openvpn_dns_servers    = [cidrhost(var.network_cidr, 2)], # The second ip is the DNS in AWS
     openvpn_dhparam_bits   = var.vpn_dhparams_bits,
-    furyagent_version      = "v0.3.0"
+    furyagent_version      = "v0.2.2"
     furyagent              = indent(6, local_file.furyagent.content),
   }
 

--- a/modules/vpc-and-vpn/vpn.tf
+++ b/modules/vpc-and-vpn/vpn.tf
@@ -87,7 +87,7 @@ resource "aws_instance" "vpn" {
   root_block_device {
     volume_size = var.vpn_instance_disk_size
   }
-  tags = var.tags
+  tags = merge({"Name": "${var.name}-vpn"}, var.tags)
 }
 
 resource "aws_eip_association" "vpn" {

--- a/modules/vpc-and-vpn/vpn.tf
+++ b/modules/vpc-and-vpn/vpn.tf
@@ -13,7 +13,7 @@ locals {
     openvpn_routes         = [{ "network" : cidrhost(var.network_cidr, 0), "netmask" : cidrnetmask(var.network_cidr) }],
     openvpn_dns_servers    = [cidrhost(var.network_cidr, 2)], # The second ip is the DNS in AWS
     openvpn_dhparam_bits   = var.vpn_dhparams_bits,
-    furyagent_version      = "v0.2.2"
+    furyagent_version      = "v0.3.0"
     furyagent              = indent(6, local_file.furyagent.content),
   }
 


### PR DESCRIPTION
This PR addresses a part of #36 :

- Updates the EKS Terraform provider to version `17.24.0`
- Updates the AWS Terraform provider to version `3.56.0` (required by the EKS provider)
- Adds `<cluster-name>-vpn-<count>` as name to the VPN EC2 instance.
- Updates the examples (backported from #41 - thanks @omissis)
- Updates docs accordingly

Upgrading from the previous version requires running the following commands for both the `vpc-and-vpn` and `eks` modules:

1. `terraform init -upgrade`
2. `terraform plan`
3. `terraform apply -refresh-only`

The expected changes when upgrading are:

1. `terraform plan` sees some external changes because of [the `tags_all` introduced in 3.38.0](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/resource-tagging#propagating-tags-to-all-resources) that allows setting tags at the provider level and will be inherited by all the rest and other new attributes that weren't managed by terraform before.
2. [The private endpoint security group rule has been renamed to allow the use of CIDR blocks and Security Groups as source](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/CHANGELOG.md#v1700---2021-05-28). The existing security group rule will be destroyed and an equivalent one will be created.
3. launch templates get a new attribute "version" changed in place.

The upgrade to [v18 includes several breaking changes](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-18.0.md) that will require some refactoring in the code. The upgrade to v18 will be addressed in another PR.

> **Warning**
> furyctl legacy does not support upgrading terraform providers yet, so this PR should not be merged until furyctl supports it.
> The PR sighupio/furyctl#221 adds the upgrade providers feature to furyctl.