### PR TITLE
feat(vpn): bump furyagent

### DIFF
--- a/modules/vpc-and-vpn/vpn.tf
+++ b/modules/vpc-and-vpn/vpn.tf
@@ -13,7 +13,7 @@ locals {
     openvpn_routes         = [{ "network" : cidrhost(var.network_cidr, 0), "netmask" : cidrnetmask(var.network_cidr) }],
     openvpn_dns_servers    = [cidrhost(var.network_cidr, 2)], # The second ip is the DNS in AWS
     openvpn_dhparam_bits   = var.vpn_dhparams_bits,
-    furyagent_version      = "v0.2.2"
+    furyagent_version      = "v0.3.0"
     furyagent              = indent(6, local_file.furyagent.content),
   }
 


### PR DESCRIPTION
BREAKING CHANGE: upgrading furyagent version changes the cloud-init
user-data and forces the recreation of the VPN instance, changing its public IP.

Leaving as Draft to check for a way to at least keep the public IPs unchanged.