### PR TITLE
feat(eks): add support to change container-runtime

### DIFF
--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -20,7 +20,7 @@ locals {
       "volume_size" : worker.volume_size,
       "subnetworks" : worker.subnetworks != null ? worker.subnetworks : var.subnetworks
       "eks_target_group_arns" : worker.eks_target_group_arns
-      "bootstrap_extra_args" : "%{if lookup(worker, "max_pods", null) != null}--use-max-pods false%{endif}",
+      "bootstrap_extra_args" : "%{if lookup(worker, "max_pods", null) != null}--use-max-pods false%{endif} %{if lookup(worker, "container_runtime", null) == "containerd"}--container-runtime containerd %{endif}",
       "kubelet_extra_args" : <<EOT
 %{if lookup(worker, "max_pods", null) != null}--max-pods ${worker.max_pods} %{endif}--node-labels=sighup.io/cluster=${var.cluster_name},sighup.io/node_pool=${worker.name},%{for k, v in worker.labels}${k}=${v},%{endfor}${worker.spot_instance ? "node.kubernetes.io/lifecycle=spot" : ""}
 %{if length(worker.taints) > 0}--register-with-taints %{for t in worker.taints}${t},%{endfor}%{endif}

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -46,6 +46,7 @@ variable "node_pools" {
     max_size              = number
     instance_type         = string
     os                    = optional(string)
+    container_runtime     = optional(string)
     spot_instance         = optional(bool)
     max_pods              = optional(number) # null to use default upstream configuration
     volume_size           = number


### PR DESCRIPTION
This PR adds a new parameter to node pools to allow specifing containerd as container runtime.

fixes #34


`cluster.yml` (redacted):

```yaml
---
kind: Cluster
metadata:
  name: 'fury-example'
spec:
  version: '1.23'
(...)
  nodePools:
  - name: containerd-nodes
    containerRuntime: containerd
    minSize: 1
    maxSize: 2
    instanceType: t3.micro
(...)
  - name: minions
    minSize: 1
    maxSize: 2
    instanceType: t3.micro

(...)
```

Resulting Nodes:

```bash
$ kubectl get nodes -o wide
NAME                                         STATUS   ROLES    AGE    VERSION                INTERNAL-IP    EXTERNAL-IP   OS-IMAGE         KERNEL-VERSION                 CONTAINER-RUNTIME
ip-10-0-172-33.eu-west-1.compute.internal    Ready    <none>   2m2s   v1.23.15-eks-49d8fe8   10.0.172.33    <none>        Amazon Linux 2   5.4.228-131.415.amzn2.x86_64   containerd://1.6.6
ip-10-0-182-179.eu-west-1.compute.internal   Ready    <none>   19m    v1.23.15-eks-49d8fe8   10.0.182.179   <none>        Amazon Linux 2   5.4.228-131.415.amzn2.x86_64   docker://20.10.17

```