### PR TITLE
fix(module,vpn): revert default vpn bucket name to v2.0.0-alpha1

### DIFF
--- a/modules/vpn/main.tf
+++ b/modules/vpn/main.tf
@@ -75,7 +75,7 @@ resource "aws_eip_association" "vpn" {
 
 // BUCKET AND IAM
 resource "aws_s3_bucket" "furyagent" {
-  bucket_prefix = coalesce(var.vpn_bucket_name_prefix, "${var.name}-${var.vpc_id}-${data.aws_region.current.name}-vpn")
+  bucket_prefix = coalesce(var.vpn_bucket_name_prefix, "${var.name}-vpn-bucket-")
   acl           = "private"
 
   force_destroy = true


### PR DESCRIPTION
Remove breaking change about vpn bucketNamePrefix.

Revert the default value to the [v2.0.0-alpha1 version](https://github.com/sighupio/fury-eks-installer/pull/60/files#diff-6718742184cafab10fedeece2735a6d81980d5848b3ad5dbe3e3a17c17fc475dR78)