### PR TITLE
add market_type and fix spot instance price on launch template

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v1.10.0-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v1.12.0-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-eks-installer?label=License)
 [![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)](https://kubernetes.slack.com/archives/C0154HYTAQH)
 

--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -15,7 +15,7 @@ locals {
       "max_size" : worker.max_size,
       // we make the double of the current given spot_price to avoid any price volatily.
       "spot_instance_price" : worker.spot_instance ? element(data.aws_ec2_spot_price.current.*.spot_price, index(var.node_pools.*.name, worker.name)) : "",
-      "spot_instance_max_price" : worker.spot_instance ? element(data.aws_ec2_spot_price.current.*.spot_price, index(var.node_pools.*.name, worker.name)) * 2: "",
+      "spot_instance_max_price" : worker.spot_instance ? element(data.aws_ec2_spot_price.current.*.spot_price, index(var.node_pools.*.name, worker.name)) * 2 : "",
       "capacity_type" : coalesce(worker.spot_instance, false) ? "SPOT" : null,
       "instance_type" : worker.instance_type,
       "tags" : [for tag_key, tag_value in merge(merge(local.default_node_tags, var.tags), worker.tags) : { "key" : tag_key, "value" : tag_value, "propagate_at_launch" : true }],
@@ -52,6 +52,7 @@ EOT
       tags                          = lookup(node_pool, "tags")
       bootstrap_extra_args          = lookup(node_pool, "bootstrap_extra_args")
       market_type                   = lookup(node_pool, "capacity_type") == "SPOT" ? "spot" : null
+      update_default_version        = true
     }
   ]
 }


### PR DESCRIPTION
When create EKS node with launch template using spot instances, they are created as "on demand". This fix the issue and update the launch template version automatically (existent nodes are not recreated but the new ones are aligned with the latest launch template version)