### PR TITLE
develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ### Terraform template
 # Local .terraform directories
+.terraform
 **/.terraform/*
 
 # .tfstate files
@@ -8,6 +9,9 @@
 
 # Crash log files
 crash.log
+
+# Lock files
+.terraform.lock.hcl
 
 # Exclude all .tfvars files, which are likely to contain sentitive data, such as
 # password, private keys, and other secrets. These should not be part of version
@@ -34,3 +38,9 @@ override.tf.json
 .terraformrc
 terraform.rc
 
+# Tools
+.envrc
+
+# Examples outputs
+examples/vpn/secrets/
+examples/vpn/ssh-users.yml

--- a/docs/upgrades/v2.0-to-v3.0.x.md
+++ b/docs/upgrades/v2.0-to-v3.0.x.md
@@ -5,10 +5,13 @@ In version 3.0 of `fury-eks-installer` we upgraded the aws provider from v3.x to
 > ⛔️ **IMPORTANT**
 > we strongly recommend reading the whole guide before starting the upgrade process to identify possible blockers.
 
+## Breaking changes
+
+- Removed the unused `availability_zone_names` variable from the `eks` module.
+
 ## Public clusters
 
 Public clusters usually rely on the `vpc` and `eks` modules, so the upgrade process is pretty straightforward:
-
 
 ```sh
 # update the provider and the modules

--- a/docs/upgrades/v2.0-to-v3.0.x.md
+++ b/docs/upgrades/v2.0-to-v3.0.x.md
@@ -1,6 +1,6 @@
 # Upgrade from v2.0.x to v3.0.x
 
-In version 3.0 of `fury-eks-installer` we upgraded the aws provider from v3.x to v4.x
+In version 3.0 of `fury-eks-installer` we upgraded the aws provider from v3.x to v5.x
 
 > ⛔️ **IMPORTANT**
 > we strongly recommend reading the whole guide before starting the upgrade process to identify possible blockers.

--- a/docs/upgrades/v2.0-to-v3.0.x.md
+++ b/docs/upgrades/v2.0-to-v3.0.x.md
@@ -1,0 +1,82 @@
+# Upgrade from v2.0.x to v3.0.x
+
+In version 3.0 of `fury-eks-installer` we upgraded the aws provider from v3.x to v4.x
+
+> ⛔️ **IMPORTANT**
+> we strongly recommend reading the whole guide before starting the upgrade process to identify possible blockers.
+
+## Public clusters
+
+Public clusters usually rely on the `vpc` and `eks` modules, so the upgrade process is pretty straightforward:
+
+
+```sh
+# update the provider and the modules
+terraform init -upgrade
+
+# apply the few changes brought in by the update vpc module
+terraform apply
+```
+
+## Private Clusters
+
+Private clusters are slightly more involved as they are using the `vpn` module.
+This requires some extra step for upgrading the buckets configuration due to changes in the provider.
+
+```sh
+# update the provider and the modules
+terraform init -upgrade
+
+# check out the changes, take note of the bucket name
+terraform plan
+
+# run the needed imports, as from the v4 of the module some of the bucket configs were moved to standalone resources
+terraform import module.vpn.aws_s3_bucket_ownership_controls.furyagent "${BUCKET_NAME}"
+terraform import module.vpn.aws_s3_bucket_server_side_encryption_configuration.furyagent "${BUCKET_NAME}"
+terraform import module.vpn.aws_s3_bucket_versioning.furyagent "${BUCKET_NAME}"
+
+# apply the few changes brought in by the update vpc module
+terraform apply
+```
+
+## Single modules
+
+Should you have a custom setup and you want to upgrade a single module, you can do so by running the following commands.
+
+### VPC Module
+
+```sh
+# update the provider and the modules
+terraform init -upgrade
+
+# apply the changes brought by the new versions
+terraform apply
+```
+
+### VPN Module
+
+```sh
+# update the provider and the modules
+terraform init -upgrade
+
+# check out the changes, take note of the bucket name
+terraform plan
+
+# run the needed imports, as from the v4 of the module some of the bucket configs were moved to standalone resources
+terraform import module.vpn.aws_s3_bucket_ownership_controls.furyagent "${BUCKET_NAME}"
+terraform import module.vpn.aws_s3_bucket_server_side_encryption_configuration.furyagent "${BUCKET_NAME}"
+terraform import module.vpn.aws_s3_bucket_versioning.furyagent "${BUCKET_NAME}"
+
+# check out no changes are left to be applied
+terraform plan
+```
+
+### EKS module
+
+```sh
+# update the provider and the modules
+terraform init -upgrade
+
+# check out no changes are left to be applied
+terraform plan
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,11 +14,10 @@ export AWS_REGION=<YOUR_REGION>
 
 # Bring up the vpc
 cd examples/vpc
-
 terraform init
 terraform apply
 
-# Bring up the vpn
+# Bring up the vpn, but only if you plan to spin a private cluster
 cd examples/vpn
 cp main.auto.tfvars.dist main.auto.tfvars
 # TASK: fill in main.auto.tfvars with your data
@@ -29,9 +28,8 @@ terraform apply
 furyagent configure openvpn-client --config=./secrets/furyagent.yml --client-name test > /tmp/fury-example-test.ovpn
 # TASK: import the generated /tmp/fury-example-test.ovpn in the openvpn client of your choice and turn it on.
 
+# Create a kubernetes cluster. Pick eks-private if you plan to spin a private cluster, or eks-public otherwise.
 cd ../eks-private
-cp main.auto.tfvars.dist main.auto.tfvars
-# TASK: fill in main.auto.tfvars with your data
 terraform init
 terraform apply
 
@@ -40,4 +38,7 @@ terraform output -raw kubeconfig > /var/tmp/.kubeconfig
 
 # Last but not least, you can verify your cluster is up and running
 KUBECONFIG=/var/tmp/.kubeconfig kubectl get nodes
+
+# Destroy the cluster
+terraform destroy
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,8 @@ terraform apply
 
 # Bring up the vpn, but only if you plan to spin a private cluster
 cd examples/vpn
+cp main.auto.tfvars.dist main.auto.tfvars
+# TASK: fill in main.auto.tfvars with your data
 terraform init
 terraform apply
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,8 +19,6 @@ terraform apply
 
 # Bring up the vpn, but only if you plan to spin a private cluster
 cd examples/vpn
-cp main.auto.tfvars.dist main.auto.tfvars
-# TASK: fill in main.auto.tfvars with your data
 terraform init
 terraform apply
 

--- a/examples/eks-private/main.auto.tfvars.dist
+++ b/examples/eks-private/main.auto.tfvars.dist
@@ -1,1 +1,0 @@
-ssh_public_key = "content of a public ssh key of your choice (eg: ~/.ssh/id_rsa.pub)"

--- a/examples/eks-private/main.tf
+++ b/examples/eks-private/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"
-    aws      = "~> 3.76.1"
+    aws      = "~> 5.22.0"
     external = "~> 2.3.1"
   }
 }

--- a/examples/eks-public/main.auto.tfvars.dist
+++ b/examples/eks-public/main.auto.tfvars.dist
@@ -1,1 +1,0 @@
-ssh_public_key = "content of a public ssh key of your choice (eg: ~/.ssh/id_rsa.pub)"

--- a/examples/eks-public/main.tf
+++ b/examples/eks-public/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"
-    aws      = "~> 3.76.1"
+    aws      = "~> 5.22.0"
     external = "~> 2.3.1"
   }
 }

--- a/examples/eks-public/main.tf
+++ b/examples/eks-public/main.tf
@@ -63,7 +63,7 @@ module "fury_public_example" {
 
   node_pools = [
     {
-      name : "m5-node-pool"
+      name : "m5-node-pool-self-managed"
       version : null # To use same value as cluster_version
       min_size : 1
       max_size : 2
@@ -99,7 +99,7 @@ module "fury_public_example" {
       # max_pods : null # To use default EKS setting set it to null or do not set it
     },
     {
-      name : "m5-node-pool-spot"
+      name : "m5-node-pool-spot-self-managed"
       min_size : 1
       max_size : 2
       instance_type : "m5.large"
@@ -133,14 +133,14 @@ module "fury_public_example" {
       max_pods : 35
     },
     {
-      name : "m5-node-pool-min-config"
+      name : "m5-node-pool-min-config-self-managed"
       min_size : 1
       max_size : 2
       instance_type : "m5.large"
       volume_size : 10
     },
     {
-      name : "m5-node-pool-null-config"
+      name : "m5-node-pool-null-config-self-managed"
       ami_id : null
       version : null
       min_size : 1
@@ -156,6 +156,22 @@ module "fury_public_example" {
       tags : null
       additional_firewall_rules : null
     },
+    {
+      type : "eks-managed"
+      name : "m5-node-pool-eks-managed"
+      min_size : 1
+      max_size : 2
+      instance_type : "m5.large"
+      subnets : null
+      labels : {
+        "node.kubernetes.io/role" : "app"
+        "sighup.io/fury-release" : "v1.25.0"
+      }
+      taints : []
+      tags : {
+        "node-tags" : "exists"
+      }
+    }
   ]
 
   tags = {

--- a/examples/vpc/main.tf
+++ b/examples/vpc/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"
-    aws      = "~> 3.76.1"
+    aws      = "~> 5.22.0"
     external = "~> 2.3.1"
   }
 }

--- a/examples/vpn/main.tf
+++ b/examples/vpn/main.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"
-    aws      = "~> 3.76.1"
+    aws      = "~> 5.22.0"
     external = "~> 2.3.1"
   }
 }

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -9,14 +9,14 @@
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.3 |
-| aws | ~> 3.76 |
+| aws | ~> 5.22 |
 | kubernetes | ~> 1.13 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.76 |
+| aws | ~> 5.22 |
 
 ## Inputs
 
@@ -73,7 +73,7 @@ terraform {
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"
-    aws      = "~> 3.76.1"
+    aws      = "~> 5.22.0"
     external = "~> 2.3.1"
   }
 }
@@ -248,7 +248,7 @@ terraform {
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"
-    aws      = "~> 3.76.1"
+    aws      = "~> 5.22.0"
     external = "~> 2.3.1"
   }
 }

--- a/modules/eks/README.md
+++ b/modules/eks/README.md
@@ -123,7 +123,6 @@ module "fury_private_example" {
   cluster_version            = "1.25"
   cluster_log_retention_days = 1
 
-  availability_zone_names = ["eu-west-1a", "eu-west-1b"]
   subnets                 = data.terraform_remote_state.vpc.outputs.private_subnets
   vpc_id                  = data.terraform_remote_state.vpc.outputs.vpc_id
 
@@ -291,7 +290,6 @@ module "fury_public_example" {
   cluster_version            = "1.25"
   cluster_log_retention_days = 1
 
-  availability_zone_names = ["eu-west-1a", "eu-west-1b"]
   subnets                 = data.terraform_remote_state.vpc.outputs.private_subnets
   vpc_id                  = data.terraform_remote_state.vpc.outputs.vpc_id
 

--- a/modules/eks/data.tf
+++ b/modules/eks/data.tf
@@ -13,7 +13,7 @@ data "aws_availability_zones" "available" {
   state = "available"
   filter {
     name   = "zone-id"
-    values = local.availability_zone_ids
+    values = coalesce(local.availability_zone_ids, "eu-west-1a")
   }
 }
 
@@ -36,7 +36,7 @@ data "aws_ami" "eks_worker" {
 
 data "aws_ec2_spot_price" "current" {
   for_each          = { for node_pool in var.node_pools : node_pool["name"] => node_pool["instance_type"] }
-  availability_zone = data.aws_availability_zones.available.names[0]
+  availability_zone = length(data.aws_availability_zones.available.names) > 0 ? data.aws_availability_zones.available.names[0] : ""
   instance_type     = each.value
 
   filter {

--- a/modules/eks/data.tf
+++ b/modules/eks/data.tf
@@ -13,7 +13,7 @@ data "aws_availability_zones" "available" {
   state = "available"
   filter {
     name   = "zone-id"
-    values = coalesce(local.availability_zone_ids, "eu-west-1a")
+    values = local.availability_zone_ids
   }
 }
 
@@ -35,8 +35,9 @@ data "aws_ami" "eks_worker" {
 }
 
 data "aws_ec2_spot_price" "current" {
-  for_each          = { for node_pool in var.node_pools : node_pool["name"] => node_pool["instance_type"] }
-  availability_zone = length(data.aws_availability_zones.available.names) > 0 ? data.aws_availability_zones.available.names[0] : ""
+  for_each = { for node_pool in var.node_pools : node_pool["name"] => node_pool["instance_type"] }
+  # Fallback wth eu-west-1a when no availability zones are available
+  availability_zone = length(data.aws_availability_zones.available.names) > 0 ? data.aws_availability_zones.available.names[0] : "eu-west-1a"
   instance_type     = each.value
 
   filter {

--- a/modules/eks/ec2.tf
+++ b/modules/eks/ec2.tf
@@ -162,10 +162,11 @@ resource "aws_security_group" "node_pool_shared" {
 }
 
 resource "aws_security_group_rule" "ssh_to_nodes" {
+  count             = (length(coalesce(var.ssh_to_nodes_allowed_cidr_blocks, [])) > 0 && length(coalesce(var.cluster_endpoint_private_access_cidrs, [])) > 0) ? 1 : 0
   type              = "ingress"
   from_port         = 22
   to_port           = 22
   protocol          = "tcp"
-  cidr_blocks       = coalescelist(var.ssh_to_nodes_allowed_cidr_blocks , var.cluster_endpoint_private_access_cidrs)
+  cidr_blocks       = coalescelist(coalesce(var.ssh_to_nodes_allowed_cidr_blocks, []), coalesce(var.cluster_endpoint_private_access_cidrs, []))
   security_group_id = aws_security_group.node_pool_shared.id
 }

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = "~> 1.3"
   required_providers {
-    aws        = "~> 3.76"
+    aws        = "~> 5.22"
     kubernetes = "~> 1.13"
   }
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -113,18 +113,6 @@ variable "node_pools_launch_kind" {
   }
 }
 
-variable "node_groups_defaults" {
-  description = "Map of values to be applied to all node groups. See `node_groups` module's documentation for more details"
-  type        = any
-  default     = {}
-}
-
-variable "node_groups" {
-  description = "Map of map of node groups to create. See `node_groups` module's documentation for more details"
-  type        = any
-  default     = {}
-}
-
 variable "tags" {
   type        = map(string)
   description = "The tags to apply to all resources"

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -200,12 +200,6 @@ variable "cluster_service_ipv4_cidr" {
 
 # Other variables
 
-variable "availability_zone_names" {
-  description = "A list of availability zones names in the region"
-  type        = list(string)
-  default     = []
-}
-
 variable "ssh_to_nodes_allowed_cidr_blocks" {
   description = "List of CIDR blocks which can access via SSH the Amazon EKS nodes"
   type        = list(string)

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -39,6 +39,7 @@ variable "ssh_public_key" {
 variable "node_pools" {
   description = "An object list defining node pools configurations"
   type = list(object({
+    type              = optional(string, "self-managed") # "eks-managed" or "self-managed"
     name              = string
     ami_id            = optional(string)
     version           = optional(string, null) # null to use cluster_version
@@ -48,7 +49,7 @@ variable "node_pools" {
     container_runtime = optional(string, "containerd")
     spot_instance     = optional(bool, false)
     max_pods          = optional(number, null) # null to use default upstream configuration
-    volume_size       = number
+    volume_size       = optional(number, 100)
     subnets           = optional(list(string), null) # null to use default upstream configuration
     labels            = optional(map(string))
     taints            = optional(list(string))
@@ -110,6 +111,18 @@ variable "node_pools_launch_kind" {
     condition     = length(regexall("^(launch_templates|launch_configurations|both)$", var.node_pools_launch_kind)) > 0
     error_message = "ERROR: Valid values are \"launch_templates\", \"launch_configurations\" and \"both\"!"
   }
+}
+
+variable "node_groups_defaults" {
+  description = "Map of values to be applied to all node groups. See `node_groups` module's documentation for more details"
+  type        = any
+  default     = {}
+}
+
+variable "node_groups" {
+  description = "Map of map of node groups to create. See `node_groups` module's documentation for more details"
+  type        = any
+  default     = {}
 }
 
 variable "tags" {

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -9,7 +9,7 @@
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.3  |
-| aws | ~> 3.76 |
+| aws | ~> 5.22 |
 | external | ~> 2.3  |
 | local | ~> 2.4  |
 | null | ~> 3.2  |
@@ -18,7 +18,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.76 |
+| aws | ~> 5.22 |
 
 ## Inputs
 
@@ -62,7 +62,7 @@ terraform {
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"
-    aws      = "~> 3.76.1"
+    aws      = "~> 5.22.0"
     external = "~> 2.3.1"
   }
 }

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     local    = "~> 2.4"
     null     = "~> 3.2"
-    aws      = "~> 3.76"
+    aws      = "~> 5.22"
     external = "~> 2.3"
   }
 }
@@ -16,13 +16,14 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.19.0"
+  version = "5.1.2"
 
   name = var.name
   cidr = var.cidr
 
   azs = local.aws_availability_zone_names
 
+  map_public_ip_on_launch = true
   private_subnets = var.private_subnetwork_cidrs
   public_subnets  = var.public_subnetwork_cidrs
 

--- a/modules/vpn/README.md
+++ b/modules/vpn/README.md
@@ -9,7 +9,7 @@
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.3  |
-| aws | ~> 3.76 |
+| aws | ~> 5.22 |
 | external | ~> 2.3  |
 | local | ~> 2.4  |
 | null | ~> 3.2  |
@@ -18,7 +18,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.76 |
+| aws | ~> 5.22 |
 | external | ~> 2.3 |
 | local | ~> 2.4 |
 | null | ~> 3.2 |
@@ -67,7 +67,7 @@ terraform {
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"
-    aws      = "~> 3.76.1"
+    aws      = "~> 5.22.0"
     external = "~> 2.3.1"
   }
 }

--- a/modules/vpn/main.tf
+++ b/modules/vpn/main.tf
@@ -85,7 +85,7 @@ resource "aws_s3_bucket" "furyagent" {
 resource "aws_s3_bucket_ownership_controls" "furyagent" {
   bucket = aws_s3_bucket.furyagent.id
   rule {
-    object_ownership = "BucketOwnerEnforced"
+    object_ownership = "BucketOwnerPreferred"
   }
 }
 

--- a/modules/vpn/main.tf
+++ b/modules/vpn/main.tf
@@ -85,7 +85,7 @@ resource "aws_s3_bucket" "furyagent" {
 resource "aws_s3_bucket_ownership_controls" "furyagent" {
   bucket = aws_s3_bucket.furyagent.id
   rule {
-    object_ownership = "BucketOwnerPreferred"
+    object_ownership = "BucketOwnerEnforced"
   }
 }
 


### PR DESCRIPTION
- Upgrade aws provider from v3 to v5 (#71)
- feat: upgrade aws provider to v5, and all the aws tf modules to their latest
- fix: tweak modules config to remove changes after v3 to v5 provider update
- fix: restore missing instruction in readme
- feat: introduce node_groups (now known as eks-managed node groups)
- chore: remove unused vars 'node_groups_defaults' and 'node_groups'
- fix: add guards to prevent eks module from breaking
- fix: use eu-west-1a as fallback AZ to get spot prices
