### PR TITLE
Enhance AMI Selection Flexibility for EKS Node Pools

### DIFF
--- a/examples/eks-public/main.tf
+++ b/examples/eks-public/main.tf
@@ -5,7 +5,7 @@
  */
 
 terraform {
-  required_version = "~> 1.4.6"
+  required_version = "1.4.6"
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"
@@ -36,7 +36,8 @@ data "aws_eks_cluster_auth" "fury_public_example" {
 data "terraform_remote_state" "vpc" {
   backend = "local"
   config = {
-    path = "${path.module}/../vpc/terraform.tfstate"
+    path = "${path.root}/../vpc/terraform.tfstate"
+    # path = "/Users/smerlos/work/github.com/sighupio/fury-eks-installer/examples/eks-public/terraform.tfstate"
   }
 }
 
@@ -47,14 +48,14 @@ resource "tls_private_key" "ssh" {
 
 module "fury_public_example" {
   source = "../../modules/eks"
-
+  # global_ami_type = "Amazon Linux 2023"
   cluster_name               = var.cluster_name # make sure to use the same name you used in the VPC and VPN module
-  cluster_version            = "1.25"
+  cluster_version            = "1.29"
   cluster_log_retention_days = 1
 
-  availability_zone_names = ["eu-west-1a", "eu-west-1b"]
-  subnets                 = data.terraform_remote_state.vpc.outputs.private_subnets
-  vpc_id                  = data.terraform_remote_state.vpc.outputs.vpc_id
+  # availability_zone_names = ["eu-west-1a", "eu-west-1b"]
+  subnets = data.terraform_remote_state.vpc.outputs.private_subnets
+  vpc_id  = data.terraform_remote_state.vpc.outputs.vpc_id
 
   cluster_endpoint_public_access  = true
   cluster_endpoint_private_access = false
@@ -137,7 +138,7 @@ module "fury_public_example" {
       min_size : 1
       max_size : 2
       instance_type : "m5.large"
-      volume_size : 10
+      volume_size : 20
     },
     {
       name : "m5-node-pool-null-config-self-managed"

--- a/examples/eks-public/main.tf
+++ b/examples/eks-public/main.tf
@@ -5,7 +5,7 @@
  */
 
 terraform {
-  required_version = "1.4.6"
+  required_version = "~> 1.4.6"
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"
@@ -37,7 +37,6 @@ data "terraform_remote_state" "vpc" {
   backend = "local"
   config = {
     path = "${path.root}/../vpc/terraform.tfstate"
-    # path = "/Users/smerlos/work/github.com/sighupio/fury-eks-installer/examples/eks-public/terraform.tfstate"
   }
 }
 
@@ -48,7 +47,7 @@ resource "tls_private_key" "ssh" {
 
 module "fury_public_example" {
   source = "../../modules/eks"
-  # global_ami_type = "Amazon Linux 2023"
+  # global_eks_nodepool_default_ami_type = "Amazon Linux 2023"
   cluster_name               = var.cluster_name # make sure to use the same name you used in the VPC and VPN module
   cluster_version            = "1.29"
   cluster_log_retention_days = 1

--- a/examples/eks-public/main.tf
+++ b/examples/eks-public/main.tf
@@ -47,7 +47,7 @@ resource "tls_private_key" "ssh" {
 
 module "fury_public_example" {
   source = "../../modules/eks"
-  # global_eks_nodepool_default_ami_type = "Amazon Linux 2023"
+
   cluster_name               = var.cluster_name # make sure to use the same name you used in the VPC and VPN module
   cluster_version            = "1.29"
   cluster_log_retention_days = 1

--- a/examples/vpc/main.tf
+++ b/examples/vpc/main.tf
@@ -5,7 +5,7 @@
  */
 
 terraform {
-  required_version = "1.4.6"
+  required_version = "~> 1.4.6"
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"

--- a/examples/vpc/main.tf
+++ b/examples/vpc/main.tf
@@ -5,7 +5,7 @@
  */
 
 terraform {
-  required_version = "~> 1.4.6"
+  required_version = "1.4.6"
   required_providers {
     local    = "~> 2.4.0"
     null     = "~> 3.2.1"

--- a/modules/eks/data.tf
+++ b/modules/eks/data.tf
@@ -26,12 +26,11 @@ data "aws_ami" "eks_worker" {
 
   filter {
     name   = "name"
-    values = ["amazon-eks-node-${each.value != null ? each.value : var.cluster_version}-v*"]
+    values = ["${local.node_pool_ami_prefix[each.key]}-${each.value != null ? each.value : var.cluster_version}-v*"]
   }
 
   most_recent = true
-
-  owners = ["amazon"]
+  owners      = ["amazon"]
 }
 
 data "aws_ec2_spot_price" "current" {

--- a/modules/eks/data.tf
+++ b/modules/eks/data.tf
@@ -19,6 +19,14 @@ data "aws_availability_zones" "available" {
 
 data "aws_region" "current" {}
 
+data "aws_ec2_instance_type" "eks_worker" {
+  for_each = {
+    for node_pool in var.node_pools : node_pool.name => node_pool
+  }
+
+  instance_type = each.value.instance_type
+}
+
 data "aws_ami" "eks_worker" {
   for_each = {
     for node_pool in var.node_pools : node_pool["name"] => lookup(node_pool, "version", null)
@@ -26,13 +34,17 @@ data "aws_ami" "eks_worker" {
 
   filter {
     name   = "name"
-    values = ["${local.node_pool_ami_prefix[each.key]}-${each.value != null ? each.value : var.cluster_version}-v*"]
+    values = ["${local.node_pool_ami_prefix[each.key]}-${coalesce(each.value, var.cluster_version)}-v*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = data.aws_ec2_instance_type.eks_worker[each.key].supported_architectures
   }
 
   most_recent = true
   owners      = ["amazon"]
 }
-
 data "aws_ec2_spot_price" "current" {
   for_each = { for node_pool in var.node_pools : node_pool["name"] => node_pool["instance_type"] }
   # Fallback wth eu-west-1a when no availability zones are available

--- a/modules/eks/locals.tf
+++ b/modules/eks/locals.tf
@@ -1,18 +1,23 @@
 locals {
   availability_zone_ids = toset([for subnet in data.aws_subnet.this : subnet.availability_zone_id])
-  # Mapping from user-friendly AMI type names to actual AMI prefixes
+  # Mapping from user-friendly AMI type names to their respective prefixes
   ami_type_prefix_map = {
-    "alinux2"    = "amazon-eks-node"
-    "alinux2023" = "amazon-eks-node-al2023-x86_64-standard"
+    "alinux2"           = "amazon-eks-node"                         # Amazon Linux 2 Standard
+    "alinux2_gpu"       = "amazon-eks-gpu-node"                     # Amazon Linux 2 GPU
+    "alinux2_arm64"     = "amazon-eks-arm64-node"                   # Amazon Linux 2 ARM64
+    "alinux2023"        = "amazon-eks-node-al2023-x86_64-standard"  # Amazon Linux 2023 Standard x86_64
+    "alinux2023_nvidia" = "amazon-eks-node-al2023-x86_64-nvidia"    # Amazon Linux 2023 NVIDIA x86_64
+    "alinux2023_neuron" = "amazon-eks-node-al2023-x86_64-neuron"    # Amazon Linux 2023 Neuron x86_64
+    "alinux2023_arm64"  = "amazon-eks-node-al2023-arm64-standard"   # Amazon Linux 2023 ARM64
   }
 
-  # Determine the AMI prefix for each node pool: use the node pool-specific AMI type if defined, otherwise fall back to the global default
+  # Determine the AMI prefix for each node pool, using the node pool-specific AMI type if defined, otherwise fall back to the global default
   node_pool_ami_prefix = {
     for node_pool in var.node_pools :
     node_pool.name => (
-      contains(keys(local.ami_type_prefix_map), coalesce(node_pool.node_pool_ami_type, var.global_ami_type))
-      ? local.ami_type_prefix_map[coalesce(node_pool.node_pool_ami_type, var.global_ami_type)]
-      : local.ami_type_prefix_map[var.global_ami_type]
+      contains(keys(local.ami_type_prefix_map), coalesce(node_pool.default_ami_type, var.global_eks_nodepool_default_ami_type))
+      ? local.ami_type_prefix_map[coalesce(node_pool.default_ami_type, var.global_eks_nodepool_default_ami_type)]
+      : local.ami_type_prefix_map[var.global_eks_nodepool_default_ami_type]
     )
   }
 }

--- a/modules/eks/locals.tf
+++ b/modules/eks/locals.tf
@@ -2,7 +2,7 @@ locals {
   availability_zone_ids = toset([for subnet in data.aws_subnet.this : subnet.availability_zone_id])
   # Mapping from user-friendly AMI type names to actual AMI prefixes
   ami_type_prefix_map = {
-    "alinux2"    = "amazon-eks-node"
+    "alinux2"    = "amazon-eks-*node"
     "alinux2023" = "amazon-eks-node-al2023-*-standard"
   }
 

--- a/modules/eks/locals.tf
+++ b/modules/eks/locals.tf
@@ -10,7 +10,7 @@ locals {
   node_pool_ami_prefix = {
     for node_pool in var.node_pools :
     node_pool.name => (
-      lookup(local.ami_type_prefix_map, coalesce(node_pool.ami_type, var.node_pools_global_ami_type), local.ami_type_prefix_map[var.node_pools_global_ami_type])
+      lookup(local.ami_type_prefix_map, coalesce(node_pool.ami_type, var.node_pools_global_ami_type))
     )
   }
 }

--- a/modules/eks/locals.tf
+++ b/modules/eks/locals.tf
@@ -10,7 +10,7 @@ locals {
   node_pool_ami_prefix = {
     for node_pool in var.node_pools :
     node_pool.name => (
-      lookup(local.ami_type_prefix_map, coalesce(node_pool.default_ami_type, var.global_eks_nodepool_default_ami_type), local.ami_type_prefix_map[var.global_eks_nodepool_default_ami_type])
+      lookup(local.ami_type_prefix_map, coalesce(node_pool.ami_type, var.node_pools_global_ami_type), local.ami_type_prefix_map[var.node_pools_global_ami_type])
     )
   }
 }

--- a/modules/eks/locals.tf
+++ b/modules/eks/locals.tf
@@ -1,23 +1,16 @@
 locals {
   availability_zone_ids = toset([for subnet in data.aws_subnet.this : subnet.availability_zone_id])
-  # Mapping from user-friendly AMI type names to their respective prefixes
+  # Mapping from user-friendly AMI type names to actual AMI prefixes
   ami_type_prefix_map = {
-    "alinux2"           = "amazon-eks-node"                         # Amazon Linux 2 Standard
-    "alinux2_gpu"       = "amazon-eks-gpu-node"                     # Amazon Linux 2 GPU
-    "alinux2_arm64"     = "amazon-eks-arm64-node"                   # Amazon Linux 2 ARM64
-    "alinux2023"        = "amazon-eks-node-al2023-x86_64-standard"  # Amazon Linux 2023 Standard x86_64
-    "alinux2023_nvidia" = "amazon-eks-node-al2023-x86_64-nvidia"    # Amazon Linux 2023 NVIDIA x86_64
-    "alinux2023_neuron" = "amazon-eks-node-al2023-x86_64-neuron"    # Amazon Linux 2023 Neuron x86_64
-    "alinux2023_arm64"  = "amazon-eks-node-al2023-arm64-standard"   # Amazon Linux 2023 ARM64
+    "alinux2"    = "amazon-eks-node"
+    "alinux2023" = "amazon-eks-node-al2023-*-standard"
   }
 
-  # Determine the AMI prefix for each node pool, using the node pool-specific AMI type if defined, otherwise fall back to the global default
+  # Determine the AMI prefix for each node pool: use the node pool-specific AMI type if defined, otherwise fall back to the global default
   node_pool_ami_prefix = {
     for node_pool in var.node_pools :
     node_pool.name => (
-      contains(keys(local.ami_type_prefix_map), coalesce(node_pool.default_ami_type, var.global_eks_nodepool_default_ami_type))
-      ? local.ami_type_prefix_map[coalesce(node_pool.default_ami_type, var.global_eks_nodepool_default_ami_type)]
-      : local.ami_type_prefix_map[var.global_eks_nodepool_default_ami_type]
+      lookup(local.ami_type_prefix_map, coalesce(node_pool.default_ami_type, var.global_eks_nodepool_default_ami_type), local.ami_type_prefix_map[var.global_eks_nodepool_default_ami_type])
     )
   }
 }

--- a/modules/eks/locals.tf
+++ b/modules/eks/locals.tf
@@ -1,3 +1,18 @@
 locals {
   availability_zone_ids = toset([for subnet in data.aws_subnet.this : subnet.availability_zone_id])
+  # Mapping from user-friendly AMI type names to actual AMI prefixes
+  ami_type_prefix_map = {
+    "alinux2"    = "amazon-eks-node"
+    "alinux2023" = "amazon-eks-node-al2023-x86_64-standard"
+  }
+
+  # Determine the AMI prefix for each node pool: use the node pool-specific AMI type if defined, otherwise fall back to the global default
+  node_pool_ami_prefix = {
+    for node_pool in var.node_pools :
+    node_pool.name => (
+      contains(keys(local.ami_type_prefix_map), coalesce(node_pool.node_pool_ami_type, var.global_ami_type))
+      ? local.ami_type_prefix_map[coalesce(node_pool.node_pool_ami_type, var.global_ami_type)]
+      : local.ami_type_prefix_map[var.global_ami_type]
+    )
+  }
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -42,7 +42,7 @@ variable "node_pools" {
     type              = optional(string, "self-managed") # "eks-managed" or "self-managed"
     name              = string
     ami_id            = optional(string)
-    ami_type  = optional(string, null)
+    ami_type          = optional(string, null)
     version           = optional(string, null) # null to use cluster_version
     min_size          = number
     max_size          = number

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -39,23 +39,24 @@ variable "ssh_public_key" {
 variable "node_pools" {
   description = "An object list defining node pools configurations"
   type = list(object({
-    type              = optional(string, "self-managed") # "eks-managed" or "self-managed"
-    name              = string
-    ami_id            = optional(string)
-    version           = optional(string, null) # null to use cluster_version
-    min_size          = number
-    max_size          = number
-    instance_type     = string
-    container_runtime = optional(string, "containerd")
-    spot_instance     = optional(bool, false)
-    max_pods          = optional(number, null) # null to use default upstream configuration
-    volume_size       = optional(number, 100)
-    volume_type       = optional(string, "gp2")
-    subnets           = optional(list(string), null) # null to use default upstream configuration
-    labels            = optional(map(string))
-    taints            = optional(list(string))
-    tags              = optional(map(string))
-    target_group_arns = optional(list(string))
+    type               = optional(string, "self-managed") # "eks-managed" or "self-managed"
+    name               = string
+    ami_id             = optional(string)
+    node_pool_ami_type = optional(string, null)
+    version            = optional(string, null) # null to use cluster_version
+    min_size           = number
+    max_size           = number
+    instance_type      = string
+    container_runtime  = optional(string, "containerd")
+    spot_instance      = optional(bool, false)
+    max_pods           = optional(number, null) # null to use default upstream configuration
+    volume_size        = optional(number, 100)
+    volume_type        = optional(string, "gp2")
+    subnets            = optional(list(string), null) # null to use default upstream configuration
+    labels             = optional(map(string))
+    taints             = optional(list(string))
+    tags               = optional(map(string))
+    target_group_arns  = optional(list(string))
     additional_firewall_rules = optional(
       object({
         cidr_blocks = optional(
@@ -229,4 +230,14 @@ variable "workers_role_name" {
   description = "IAM role name for the EKS workers"
   type        = string
   default     = ""
+}
+
+variable "global_ami_type" {
+  type        = string
+  description = "Global default AMI type used for EKS worker nodes. This will apply to all node pools unless overridden by a specific node pool."
+  default     = "alinux2"
+  validation {
+    condition     = contains(["alinux2", "alinux2023"], var.global_ami_type)
+    error_message = "The global AMI type must be either 'alinux2' or 'alinux2023'."
+  }
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -237,7 +237,7 @@ variable "global_eks_nodepool_default_ami_type" {
   description = "Global default AMI type used for EKS worker nodes. This will apply to all node pools unless overridden by a specific node pool."
   default     = "alinux2"
   validation {
-    condition     = contains(["alinux2", "alinux2023", "alinux2_gpu", "alinux2023_nvidia", "alinux2023_neuron", "alinux2023_arm64", "alinux2_arm64"], var.global_eks_nodepool_default_ami_type)
-    error_message = "The global AMI type must be one of the following: alinux2, alinux2023, alinux2_gpu, alinux2023_nvidia, alinux2023_neuron, alinux2023_arm64, alinux2_arm64."
+    condition     = contains(["alinux2", "alinux2023"], var.global_eks_nodepool_default_ami_type)
+    error_message = "The global AMI type must be either 'alinux2' or 'alinux2023'."
   }
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -39,24 +39,24 @@ variable "ssh_public_key" {
 variable "node_pools" {
   description = "An object list defining node pools configurations"
   type = list(object({
-    type               = optional(string, "self-managed") # "eks-managed" or "self-managed"
-    name               = string
-    ami_id             = optional(string)
-    node_pool_ami_type = optional(string, null)
-    version            = optional(string, null) # null to use cluster_version
-    min_size           = number
-    max_size           = number
-    instance_type      = string
-    container_runtime  = optional(string, "containerd")
-    spot_instance      = optional(bool, false)
-    max_pods           = optional(number, null) # null to use default upstream configuration
-    volume_size        = optional(number, 100)
-    volume_type        = optional(string, "gp2")
-    subnets            = optional(list(string), null) # null to use default upstream configuration
-    labels             = optional(map(string))
-    taints             = optional(list(string))
-    tags               = optional(map(string))
-    target_group_arns  = optional(list(string))
+    type              = optional(string, "self-managed") # "eks-managed" or "self-managed"
+    name              = string
+    ami_id            = optional(string)
+    default_ami_type  = optional(string, null)
+    version           = optional(string, null) # null to use cluster_version
+    min_size          = number
+    max_size          = number
+    instance_type     = string
+    container_runtime = optional(string, "containerd")
+    spot_instance     = optional(bool, false)
+    max_pods          = optional(number, null) # null to use default upstream configuration
+    volume_size       = optional(number, 100)
+    volume_type       = optional(string, "gp2")
+    subnets           = optional(list(string), null) # null to use default upstream configuration
+    labels            = optional(map(string))
+    taints            = optional(list(string))
+    tags              = optional(map(string))
+    target_group_arns = optional(list(string))
     additional_firewall_rules = optional(
       object({
         cidr_blocks = optional(
@@ -232,12 +232,12 @@ variable "workers_role_name" {
   default     = ""
 }
 
-variable "global_ami_type" {
+variable "global_eks_nodepool_default_ami_type" {
   type        = string
   description = "Global default AMI type used for EKS worker nodes. This will apply to all node pools unless overridden by a specific node pool."
   default     = "alinux2"
   validation {
-    condition     = contains(["alinux2", "alinux2023"], var.global_ami_type)
-    error_message = "The global AMI type must be either 'alinux2' or 'alinux2023'."
+    condition     = contains(["alinux2", "alinux2023", "alinux2_gpu", "alinux2023_nvidia", "alinux2023_neuron", "alinux2023_arm64", "alinux2_arm64"], var.global_eks_nodepool_default_ami_type)
+    error_message = "The global AMI type must be one of the following: alinux2, alinux2023, alinux2_gpu, alinux2023_nvidia, alinux2023_neuron, alinux2023_arm64, alinux2_arm64."
   }
 }

--- a/modules/eks/variables.tf
+++ b/modules/eks/variables.tf
@@ -42,7 +42,7 @@ variable "node_pools" {
     type              = optional(string, "self-managed") # "eks-managed" or "self-managed"
     name              = string
     ami_id            = optional(string)
-    default_ami_type  = optional(string, null)
+    ami_type  = optional(string, null)
     version           = optional(string, null) # null to use cluster_version
     min_size          = number
     max_size          = number
@@ -232,12 +232,12 @@ variable "workers_role_name" {
   default     = ""
 }
 
-variable "global_eks_nodepool_default_ami_type" {
+variable "node_pools_global_ami_type" {
   type        = string
   description = "Global default AMI type used for EKS worker nodes. This will apply to all node pools unless overridden by a specific node pool."
   default     = "alinux2"
   validation {
-    condition     = contains(["alinux2", "alinux2023"], var.global_eks_nodepool_default_ami_type)
+    condition     = contains(["alinux2", "alinux2023"], var.node_pools_global_ami_type)
     error_message = "The global AMI type must be either 'alinux2' or 'alinux2023'."
   }
 }


### PR DESCRIPTION
This PR introduces a major improvement to the flexibility of Amazon EKS node pool configuration by allowing dynamic AMI type selection both globally and per node pool. The goal of this enhancement is to streamline the process of managing different AMI types (such as Amazon Linux 2 and Amazon Linux 2023) while providing the ability to customize each node pool independently or rely on a global default.

**Key Features:**


-  Global AMI Type (global_ami_type): A new variable is introduced to define the default AMI type across all node pools unless overridden. The supported options are alinux2 (Amazon Linux 2) and alinux2023 (Amazon Linux 2023).
-  Node Pool-Specific AMI Selection (node_pool_ami_type): Each node pool can now specify its own AMI type if different from the global default. This increases flexibility when managing node pools that require different operating systems or AMI versions.
-  Dynamic AMI Prefixing: The AMI prefix for each node pool is dynamically selected based on the global or specific node pool AMI type. This ensures that the correct AMI is always chosen during resource creation.

**Improvements:**

-  Enhanced support for mixed environments where node pools require different AMI types.
-  Retained backward compatibility: if no node_pool_ami_type is specified, the global default applies, preserving current setups without requiring changes.
-  Cleaner and more concise handling of AMI lookup logic, reducing potential errors or inconsistencies.


**Why This Is Important:**

This PR simplifies the configuration process for environments requiring multiple AMI types. It allows operators to define a global AMI type while having the freedom to specify individual configurations for specific node pools when needed.