### PR TITLE
fix(module,eks): disable using custom ami_id on eks-managed node group

### DIFF
--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -132,6 +132,8 @@ locals {
         var.tags,
         { Name : "${var.cluster_name}-${lookup(node_pool, "name")}" }
       )
+      update_default_version = true
+      version = coalesce(node_pool.version, var.cluster_version)
 
     } if lookup(node_pool, "type") == "eks-managed"
   ]


### PR DESCRIPTION
EKS managed node group will be handled totally from AWS. If you need to use custom `ami` please use the `self-managed` node group type