### PR TITLE
feat: release v3.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v3.1.2-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v3.1.3-blue)
 ![License](https://img.shields.io/github/license/sighupio/installer-eks?label=License)
 [![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)](https://kubernetes.slack.com/archives/C0154HYTAQH)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v3.1.3-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v3.3.1-blue)
 ![License](https://img.shields.io/github/license/sighupio/installer-eks?label=License)
 [![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)](https://kubernetes.slack.com/archives/C0154HYTAQH)
 

--- a/docs/releases/v3.3.1.md
+++ b/docs/releases/v3.3.1.md
@@ -1,0 +1,12 @@
+# Installer EKS Module Release v3.3.1
+
+Welcome to the latest release of the `installer-eks` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution)
+maintained by team SIGHUP.
+
+## Component Images 🚢
+
+| Component           | Supported Version                                                                                   | Previous Version |
+| ------------------- | --------------------------------------------------------------------------------------------------- | ---------------- |
+| `terraform-aws-modules/terraform-aws-eks` | [`v17.24.0`](https://github.com/terraform-aws-modules/terraform-aws-eks/releases/tag/v17.24.0) | `No Update`          |
+| `terraform-aws-modules/terraform-aws-vpc` | [`v5.1.2`](https://github.com/terraform-aws-modules/terraform-aws-vpc/releases/tag/v5.1.2) | `No Update`      |
+

--- a/examples/eks-private/main.tf
+++ b/examples/eks-private/main.tf
@@ -56,7 +56,7 @@ module "fury_private_example" {
   source = "../../modules/eks"
 
   cluster_name               = var.cluster_name # make sure to use the same name you used in the VPC and VPN module
-  cluster_version            = "1.33"
+  cluster_version            = "1.34"
   cluster_log_retention_days = 1
 
   subnets                 = data.terraform_remote_state.vpc.outputs.private_subnets

--- a/examples/eks-public/main.tf
+++ b/examples/eks-public/main.tf
@@ -49,7 +49,7 @@ module "fury_public_example" {
   source = "../../modules/eks"
 
   cluster_name               = var.cluster_name # make sure to use the same name you used in the VPC and VPN module
-  cluster_version            = "1.33"
+  cluster_version            = "1.34"
   cluster_log_retention_days = 1
 
   # availability_zone_names = ["eu-west-1a", "eu-west-1b"]
@@ -92,7 +92,7 @@ module "fury_public_example" {
       }
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-self-managed"
-        "sighup.io/fury-release" : "v1.33.0"
+        "sighup.io/fury-release" : "v1.34.0"
       }
       taints : []
       tags : {
@@ -127,7 +127,7 @@ module "fury_public_example" {
       }
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-spot-self-managed"
-        "sighup.io/fury-release" : "v1.33.0"
+        "sighup.io/fury-release" : "v1.34.0"
       }
       tags : {
         "node-tags" : "exists"
@@ -142,7 +142,7 @@ module "fury_public_example" {
       volume_size : 20
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-min-config-self-managed"
-        "sighup.io/fury-release" : "v1.33.0"
+        "sighup.io/fury-release" : "v1.34.0"
       }
     },
     {
@@ -154,7 +154,7 @@ module "fury_public_example" {
       volume_size : 20
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-alinux2023-self-managed"
-        "sighup.io/fury-release" : "v1.33.0"
+        "sighup.io/fury-release" : "v1.34.0"
       }
     },
     {
@@ -175,7 +175,7 @@ module "fury_public_example" {
       additional_firewall_rules : null
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-null-config-self-managed"
-        "sighup.io/fury-release" : "v1.33.0"
+        "sighup.io/fury-release" : "v1.34.0"
       }
     },
     {
@@ -187,7 +187,7 @@ module "fury_public_example" {
       volume_size : 20
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-arm64-self-managed"
-        "sighup.io/fury-release" : "v1.33.0"
+        "sighup.io/fury-release" : "v1.34.0"
       }
     },
     {
@@ -199,7 +199,7 @@ module "fury_public_example" {
       subnets : null
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-eks-managed"
-        "sighup.io/fury-release" : "v1.33.0"
+        "sighup.io/fury-release" : "v1.34.0"
       }
       taints : []
       tags : {
@@ -217,7 +217,7 @@ module "fury_public_example" {
       subnets : null
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-arm64-eks-managed"
-        "sighup.io/fury-release" : "v1.33.0"
+        "sighup.io/fury-release" : "v1.34.0"
       }
       taints : []
       tags : {
@@ -235,7 +235,7 @@ module "fury_public_example" {
       subnets : null
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-alinux2023-arm64-eks-managed"
-        "sighup.io/fury-release" : "v1.33.0"
+        "sighup.io/fury-release" : "v1.34.0"
       }
       taints : []
       tags : {
@@ -253,7 +253,7 @@ module "fury_public_example" {
       subnets : null
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-alinux2023-eks-managed"
-        "sighup.io/fury-release" : "v1.33.0"
+        "sighup.io/fury-release" : "v1.34.0"
       }
       taints : []
       tags : {


### PR DESCRIPTION
## Summary 💡
This PR updates the installer-eks to support kubernetes 1.34

## Breaking Changes 💔
None

## Tests performed 🧪
Tested with `examples/eks-public`
```
❯ aws eks describe-cluster \
  --name "$CLUSTER_NAME"  --region eu-west-1 | cat
{
    "cluster": {
        "name": "fury-public-example",
        "version": "1.34",
        ....
```