### PR TITLE
fix(module,eks,vendor): add missing propagated tags to self-managed launch template 

### DIFF
--- a/docs/releases/v3.3.1.md
+++ b/docs/releases/v3.3.1.md
@@ -1,0 +1,18 @@
+# Installer EKS Module Release v3.3.1
+
+Welcome to the latest release of the `installer-eks` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution)
+maintained by team SIGHUP.
+
+This release fixes a bug where tags defined in worker_groups_launch_template configuration were not being propagated to the AWS launch template resource for self-managed node groups.[PR #99](https://github.com/sighupio/installer-eks/pull/99)
+
+## Component Images 🚢
+
+| Component           | Supported Version                                                                                   | Previous Version |
+| ------------------- | --------------------------------------------------------------------------------------------------- | ---------------- |
+| `terraform-aws-modules/terraform-aws-eks` | [`v17.24.0`](https://github.com/terraform-aws-modules/terraform-aws-eks/releases/tag/v17.24.0) | `No Update`          |
+| `terraform-aws-modules/terraform-aws-vpc` | [`v5.1.2`](https://github.com/terraform-aws-modules/terraform-aws-vpc/releases/tag/v5.1.2) | `No Update`      |
+
+
+## Breaking changes
+
+None

--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -101,10 +101,7 @@ locals {
       subnets                = coalesce(lookup(node_pool, "subnets", null), var.subnets)
       tags = [
         for key, value in merge(
-          merge(
-            local.default_node_tags,
-            var.tags
-          ),
+          local.default_node_tags,
           coalesce(lookup(node_pool, "tags", null), {})
           ) : {
           key                 = key


### PR DESCRIPTION
### Summary 💡

This PR fixes a bug where tags defined in `worker_groups_launch_template` configuration were not being propagated to the AWS launch template resource for self-managed node groups.

Closes: <!-- Add issue number if exists -->

Relates: <!-- Add related PRs if any -->

### Description 📝

The launch template resource for self-managed worker groups was missing the propagation of tags defined in the `tags` field of `worker_groups_launch_template` configuration.

This ensures that custom tags defined at the worker group level are correctly applied to the launch template and propagate to EC2 instances.

### Breaking Changes 💔

None. This is a bug fix that adds missing functionality without changing existing behavior.

### Tests performed 🧪

- [ ] Tested with worker group configuration including custom tags
- [ ] Verified tags appear on launch template resource
- [ ] Verified tags propagate to EC2 instances
- [ ] Tested existing configurations without custom tags continue to work
- [ ] Verified changes against v3.3.0 baseline

### Future work 🔧

None identified.

### Checklist ☑️

- [ ] All tests have been successfully performed
- [ ] `unreleased.md` file has been created or updated (if needed)
- [ ] Documentation has been updated (if needed)
- [ ] Examples have been updated (if needed)
- [ ] CI is passing