### PR TITLE
Fix/unreleased

### DIFF
--- a/docs/releases/v3.3.1.md
+++ b/docs/releases/v3.3.1.md
@@ -1,0 +1,18 @@
+# Installer EKS Module Release v3.3.1
+
+Welcome to the latest release of the `installer-eks` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution)
+maintained by team SIGHUP.
+
+This release fixes a bug where tags defined in worker_groups_launch_template configuration were not being propagated to the AWS launch template resource for self-managed node groups.[PR #99](https://github.com/sighupio/installer-eks/pull/99)
+
+## Component Images 🚢
+
+| Component           | Supported Version                                                                                   | Previous Version |
+| ------------------- | --------------------------------------------------------------------------------------------------- | ---------------- |
+| `terraform-aws-modules/terraform-aws-eks` | [`v17.24.0`](https://github.com/terraform-aws-modules/terraform-aws-eks/releases/tag/v17.24.0) | `No Update`          |
+| `terraform-aws-modules/terraform-aws-vpc` | [`v5.1.2`](https://github.com/terraform-aws-modules/terraform-aws-vpc/releases/tag/v5.1.2) | `No Update`      |
+
+
+## Breaking changes
+
+None

--- a/docs/releases/v3.4.0.md
+++ b/docs/releases/v3.4.0.md
@@ -1,4 +1,4 @@
-# Installer EKS Module Release v3.3.1
+# Installer EKS Module Release v3.4.0
 
 Welcome to the latest release of the `installer-eks` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution)
 maintained by team SIGHUP.

--- a/modules/eks/eks.tf
+++ b/modules/eks/eks.tf
@@ -101,10 +101,7 @@ locals {
       subnets                = coalesce(lookup(node_pool, "subnets", null), var.subnets)
       tags = [
         for key, value in merge(
-          merge(
-            local.default_node_tags,
-            var.tags
-          ),
+          local.default_node_tags,
           coalesce(lookup(node_pool, "tags", null), {})
           ) : {
           key                 = key


### PR DESCRIPTION
### Summary 💡

This PR fixes the release notes for v3.3.1 and corrects a bug in the EKS module where tags were not properly propagated to self-managed node groups.

Closes: #99

### Description 📝

**Changes made:**

1. **Fixed v3.3.1 release notes** - Corrected the description to accurately reflect the bug fix for tag propagation in worker_groups_launch_template instead of the vpn_furyagent_path feature (which belongs to v3.4.0)

2. **Created v3.4.0 release notes** - Added proper release notes for the vpn_furyagent_path feature introduction

3. **Fixed tag propagation bug in EKS module** - Removed duplicate merge of `var.tags` in the worker_groups_launch_template configuration. The tags were being merged twice, causing issues with tag propagation to AWS launch template resources for self-managed node groups.

**Technical details:**
In `modules/eks/eks.tf`, the tags block was incorrectly merging `var.tags` with `local.default_node_tags` before merging with node pool specific tags. This has been simplified to only merge `local.default_node_tags` with node pool tags, ensuring proper tag propagation.

### Breaking Changes 💔

None

### Tests performed 🧪

- [ ] Verified release notes accuracy
- [ ] Tested tag propagation on self-managed node groups
- [ ] Validated terraform plan with the changes

### Future work 🔧

None