### PR TITLE
feat: release v3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v3.4.0-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v3.5.0-blue)
 ![License](https://img.shields.io/github/license/sighupio/installer-eks?label=License)
 [![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)](https://kubernetes.slack.com/archives/C0154HYTAQH)
 

--- a/docs/releases/v3.5.0.md
+++ b/docs/releases/v3.5.0.md
@@ -1,0 +1,21 @@
+# Installer EKS Module Release v3.5.0
+
+Welcome to the latest release of the `installer-eks` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution)
+maintained by team SIGHUP.
+
+This release tests compatibility with Kubernetes 1.35 in the EKS installer.
+
+## Component Images 🚢
+
+| Component | Supported Version | Previous Version |
+| --------- | ----------------- | ---------------- |
+| `terraform-aws-modules/terraform-aws-eks` | [`v17.24.0`](https://github.com/terraform-aws-modules/terraform-aws-eks/releases/tag/v17.24.0) | `No Update` |
+| `terraform-aws-modules/terraform-aws-vpc` | [`v5.1.2`](https://github.com/terraform-aws-modules/terraform-aws-vpc/releases/tag/v5.1.2) | `No Update` |
+
+## Breaking Changes 💔
+
+Cgroup v1 support removed: Kubernetes 1.35 removes cgroup v1 support. The kubelet will refuse to start on nodes using cgroup v1.
+
+Users of this module are not affected in standard configurations: AL2023 EKS-optimized AMIs (selected automatically or via `ami_type: "alinux2023"`) and EKS-managed node groups all use cgroup v2 by default.
+
+Action required only for users supplying a custom `ami_id` pointing to a non-EKS-optimized image (e.g. Ubuntu, Debian, RHEL) that was built or configured with cgroup v1 (e.g. via `systemd.unified_cgroup_hierarchy=0` in the GRUB kernel parameters). In that case, before upgrading to 1.35, users should verify nodes are on cgroup v2 by running `stat -fc %T /sys/fs/cgroup/`, the output must be `cgroup2fs`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -42,5 +42,3 @@ KUBECONFIG=/var/tmp/.kubeconfig kubectl get nodes
 # Destroy the cluster
 tofu destroy
 ```
-
-> **Note**: You can use `terraform` instead of `tofu` if you prefer, but OpenTofu is now supported and recommended.

--- a/examples/eks-private/main.tf
+++ b/examples/eks-private/main.tf
@@ -66,6 +66,8 @@ module "fury_private_example" {
 
   ssh_public_key = tls_private_key.ssh.public_key_openssh
 
+  node_pools_global_ami_type = "alinux2023"
+
   node_pools = [
     {
       name : "m5-node-pool"
@@ -92,7 +94,7 @@ module "fury_private_example" {
       }
       labels : {
         "node.kubernetes.io/role" : "app"
-        "sighup.io/fury-release" : "v1.25.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
       taints : []
       tags : {
@@ -108,7 +110,7 @@ module "fury_private_example" {
       spot_instance : true # optionally create spot instances
       # ami_id : "ami-01eb5348cab8e4902" # optionally define a custom AMI
       volume_size : 100
-      container_runtime = "docker"
+      container_runtime = "containerd"
       additional_firewall_rules : {
         cidr_blocks = [
           {
@@ -127,7 +129,7 @@ module "fury_private_example" {
       }
       labels : {
         "node.kubernetes.io/role" : "app"
-        "sighup.io/fury-release" : "v1.25.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
       tags : {
         "node-tags" : "exists"
@@ -139,7 +141,51 @@ module "fury_private_example" {
       min_size : 1
       max_size : 2
       instance_type : "m5.large"
-      volume_size : 10
+      volume_size : 20
+    },
+    {
+      name : "m5-node-pool-arm64-self-managed"
+      min_size : 1
+      max_size : 2
+      instance_type : "t4g.large"
+      volume_size : 20
+      labels : {
+        "node.kubernetes.io/role" : "m5-node-pool-arm64-self-managed"
+        "sighup.io/fury-release" : "v1.35.0"
+      }
+    },
+    {
+      type : "eks-managed"
+      name : "m5-node-pool-eks-managed"
+      min_size : 1
+      max_size : 2
+      instance_type : "m5.large"
+      subnets : null
+      labels : {
+        "node.kubernetes.io/role" : "m5-node-pool-eks-managed"
+        "sighup.io/fury-release" : "v1.35.0"
+      }
+      taints : []
+      tags : {
+        "node-tags" : "exists"
+      }
+    },
+    {
+      type : "eks-managed"
+      name : "m5-node-pool-arm64-eks-managed"
+      min_size : 1
+      max_size : 2
+      instance_type : "t4g.large"
+      spot_instance : true
+      subnets : null
+      labels : {
+        "node.kubernetes.io/role" : "m5-node-pool-arm64-eks-managed"
+        "sighup.io/fury-release" : "v1.35.0"
+      }
+      taints : []
+      tags : {
+        "node-tags" : "exists"
+      }
     },
     {
       name : "m5-node-pool-null-config"

--- a/examples/eks-private/main.tf
+++ b/examples/eks-private/main.tf
@@ -56,7 +56,7 @@ module "fury_private_example" {
   source = "../../modules/eks"
 
   cluster_name               = var.cluster_name # make sure to use the same name you used in the VPC and VPN module
-  cluster_version            = "1.34"
+  cluster_version            = "1.35"
   cluster_log_retention_days = 1
 
   subnets                 = data.terraform_remote_state.vpc.outputs.private_subnets

--- a/examples/eks-public/main.tf
+++ b/examples/eks-public/main.tf
@@ -49,7 +49,7 @@ module "fury_public_example" {
   source = "../../modules/eks"
 
   cluster_name               = var.cluster_name # make sure to use the same name you used in the VPC and VPN module
-  cluster_version            = "1.34"
+  cluster_version            = "1.35"
   cluster_log_retention_days = 1
 
   # availability_zone_names = ["eu-west-1a", "eu-west-1b"]
@@ -92,7 +92,7 @@ module "fury_public_example" {
       }
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-self-managed"
-        "sighup.io/fury-release" : "v1.34.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
       taints : []
       tags : {
@@ -127,7 +127,7 @@ module "fury_public_example" {
       }
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-spot-self-managed"
-        "sighup.io/fury-release" : "v1.34.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
       tags : {
         "node-tags" : "exists"
@@ -142,7 +142,7 @@ module "fury_public_example" {
       volume_size : 20
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-min-config-self-managed"
-        "sighup.io/fury-release" : "v1.34.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
     },
     {
@@ -154,7 +154,7 @@ module "fury_public_example" {
       volume_size : 20
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-alinux2023-self-managed"
-        "sighup.io/fury-release" : "v1.34.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
     },
     {
@@ -175,7 +175,7 @@ module "fury_public_example" {
       additional_firewall_rules : null
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-null-config-self-managed"
-        "sighup.io/fury-release" : "v1.34.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
     },
     {
@@ -187,7 +187,7 @@ module "fury_public_example" {
       volume_size : 20
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-arm64-self-managed"
-        "sighup.io/fury-release" : "v1.34.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
     },
     {
@@ -199,7 +199,7 @@ module "fury_public_example" {
       subnets : null
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-eks-managed"
-        "sighup.io/fury-release" : "v1.34.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
       taints : []
       tags : {
@@ -217,7 +217,7 @@ module "fury_public_example" {
       subnets : null
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-arm64-eks-managed"
-        "sighup.io/fury-release" : "v1.34.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
       taints : []
       tags : {
@@ -235,7 +235,7 @@ module "fury_public_example" {
       subnets : null
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-alinux2023-arm64-eks-managed"
-        "sighup.io/fury-release" : "v1.34.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
       taints : []
       tags : {
@@ -253,7 +253,7 @@ module "fury_public_example" {
       subnets : null
       labels : {
         "node.kubernetes.io/role" : "m5-node-pool-alinux2023-eks-managed"
-        "sighup.io/fury-release" : "v1.34.0"
+        "sighup.io/fury-release" : "v1.35.0"
       }
       taints : []
       tags : {

--- a/examples/eks-public/main.tf
+++ b/examples/eks-public/main.tf
@@ -108,7 +108,7 @@ module "fury_public_example" {
       spot_instance : true # optionally create spot instances
       # ami_id : "ami-01eb5348cab8e4902" # optionally define a custom AMI
       volume_size : 100
-      container_runtime = "docker"
+      container_runtime = "containerd"
       additional_firewall_rules : {
         cidr_blocks = [
           {
@@ -169,7 +169,6 @@ module "fury_public_example" {
       max_pods : null
       volume_size : 100
       subnets : null
-      labels : null
       taints : null
       tags : null
       additional_firewall_rules : null
@@ -182,7 +181,6 @@ module "fury_public_example" {
       name : "m5-node-pool-arm64-self-managed"
       min_size : 1
       max_size : 2
-      ami_id           = "ami-05fe3c54efa9eab36"
       instance_type : "t4g.large"
       volume_size : 20
       labels : {
@@ -211,7 +209,6 @@ module "fury_public_example" {
       name : "m5-node-pool-arm64-eks-managed"
       min_size : 1
       max_size : 2
-      ami_id           = "ami-05fe3c54efa9eab36"
       instance_type : "t4g.large"
       spot_instance : true # optionally create spot instances
       subnets : null
@@ -229,7 +226,6 @@ module "fury_public_example" {
       name : "m5-node-pool-alinux2023-arm64-eks-managed"
       min_size : 1
       max_size : 2
-      ami_id           = "ami-05fe3c54efa9eab36"
       instance_type : "t4g.large"
       spot_instance : true # optionally create spot instances
       subnets : null


### PR DESCRIPTION
### Summary 💡

This release tests compatibility with Kubernetes 1.35 in the EKS installer.

### Description 📝

See above.

### Breaking Changes 💔

Cgroup v1 support removed: Kubernetes 1.35 removes cgroup v1 support. The kubelet will refuse to start on nodes using cgroup v1.
Users of this module are not affected in standard configurations: AL2023 EKS-optimized AMIs (selected automatically or via `ami_type: "alinux2023"`) and EKS-managed node groups all use cgroup v2 by default.

### Tests performed 🧪

- [x] Tested a clean deploy with EKS v1.35
- [x] Tested by upgrading from EKS v1.34 to this branch with v1.35

### Future work 🔧

None.

